### PR TITLE
Fix ESLint paths and update README

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,10 +35,10 @@ module.exports = {
       },
       alias: {
         map: [
-          ['@', './electron-react-app/src'],
-          ['@main', './electron-react-app/src/main'],
-          ['@renderer', './electron-react-app/src/renderer'],
-          ['@shared', './electron-react-app/src/shared']
+          ['@', './src'],
+          ['@main', './src/main'],
+          ['@renderer', './src/renderer'],
+          ['@shared', './src/shared']
         ]
       }
     }
@@ -112,11 +112,11 @@ module.exports = {
       }
     },
     {
-      files: ['electron-react-app/src/main/**/*.js'],
+      files: ['src/main/**/*.js'],
       env: {
         browser: false,
         node: true
       }
     }
   ]
-}; 
+};

--- a/README.md
+++ b/README.md
@@ -59,21 +59,19 @@ Using **Ollama** for local AI processing, StratoSort intelligently categorizes a
 
 ```
 stratosort/
-├── electron-react-app/     # Main Electron application
-│   ├── src/
-│   │   ├── main/          # Main process (backend)
-│   │   │   ├── services/  # Core services
-│   │   │   ├── utils/     # Utility functions
-│   │   │   └── workers/   # Background workers
-│   │   ├── renderer/      # Renderer process (frontend)
-│   │   │   ├── components/# React components
-│   │   │   └── styles/    # CSS and styling
-│   │   └── preload/       # Preload scripts
-│   ├── assets/            # Icons and resources
-│   └── config/            # Configuration files
-├── tests/                 # Test suites
-├── scripts/               # Build and setup scripts
-└── docs/                  # Documentation
+├── src/                  # Application source
+│   ├── main/             # Main process (backend)
+│   │   ├── analysis/     # Document analysis logic
+│   │   ├── services/     # Core services
+│   │   └── errors/       # Custom errors
+│   ├── renderer/         # Renderer process (frontend)
+│   │   ├── components/   # React components
+│   │   └── styles/       # CSS and styling
+│   ├── preload/          # Preload scripts
+│   └── shared/           # Shared utilities
+├── assets/               # Icons and resources
+├── test/                 # Test suites
+└── webpack.config.js     # Build configuration
 ```
 
 ## 🚀 Getting Started


### PR DESCRIPTION
## Summary
- update architecture diagram to show `src/main`, `src/renderer`, etc.
- fix ESLint alias paths and overrides
- add trailing newline to ESLint config

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854d20b24548324bd2f5f6ffce7b839