### PR TITLE
Fix .env loading via dotenv-flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.5.0",
+        "dotenv-flow": "^4.1.0",
         "electron-debug": "^3.2.0",
         "electron-log": "^4.4.8",
         "electron-updater": "^6.1.4",
@@ -10103,6 +10104,18 @@
       "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/dotenv-flow": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv-flow/-/dotenv-flow-4.1.0.tgz",
+      "integrity": "sha512-0cwP9jpQBQfyHwvE0cRhraZMkdV45TQedA8AAUZMsFzvmLcQyc1HPv+oX0OOYwLFjIlvgVepQ+WuQHbqDaHJZg==",
+      "license": "MIT",
+      "dependencies": {
+        "dotenv": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
     },
     "node_modules/duck": {
       "version": "0.1.12",

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
   },
   "dependencies": {
     "dotenv": "^16.5.0",
+    "dotenv-flow": "^4.1.0",
     "electron-debug": "^3.2.0",
     "electron-log": "^4.4.8",
     "electron-updater": "^6.1.4",

--- a/src/main/simple-main.js
+++ b/src/main/simple-main.js
@@ -4,6 +4,10 @@ const fs = require('fs').promises;
 const { existsSync } = require('fs');
 const os = require('os');
 const { performance } = require('perf_hooks');
+
+// Load environment variables from .env, .env.local, etc.
+require('dotenv-flow').config();
+
 const isDev = process.env.NODE_ENV === 'development';
 
 // Import error handling system


### PR DESCRIPTION
## Summary
- install `dotenv-flow`
- load environment variables in the main process

## Testing
- `npm test`
- `npm run build:dev`


------
https://chatgpt.com/codex/tasks/task_e_6857057dc0bc832493d1c67232ba20e8