### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ npm run format           # Code formatting
 3. Follow the established code patterns and architecture
 4. Ensure all tests pass (`npm test`)
 5. Submit pull request with detailed description
+6. Continuous integration will run automatically via [GitHub Actions](.github/workflows/ci.yml)
 
 ### Code Standards
 - **Clean Code**: Follow established patterns, no technical debt


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run lint and tests on Node 18
- document the CI pipeline in the contributing section

## Testing
- `npm ci`
- `npm run lint` *(fails: 885 errors)*
- `npm test` *(fails: 1 test suite failed)*

------
https://chatgpt.com/codex/tasks/task_e_686068db2bec8324a23cf1ee54117ee1