### PR TITLE
feat: save settings atomically

### DIFF
--- a/src/main/services/SettingsService.js
+++ b/src/main/services/SettingsService.js
@@ -1,6 +1,7 @@
 const { app } = require('electron');
 const fs = require('fs').promises;
 const path = require('path');
+const { backupAndReplace } = require('../../shared/atomicFileOperations');
 
 class SettingsService {
   constructor() {
@@ -37,7 +38,13 @@ class SettingsService {
   async save(settings) {
     const merged = { ...this.defaults, ...(settings || {}) };
     await fs.mkdir(path.dirname(this.settingsPath), { recursive: true });
-    await fs.writeFile(this.settingsPath, JSON.stringify(merged, null, 2));
+    const result = await backupAndReplace(
+      this.settingsPath,
+      JSON.stringify(merged, null, 2)
+    );
+    if (!result.success) {
+      throw new Error(result.error || 'Failed to save settings');
+    }
     return merged;
   }
 }

--- a/test/react-app.test.js
+++ b/test/react-app.test.js
@@ -51,7 +51,7 @@ describe('StratoSort React App', () => {
         'utf8'
       );
       // These should appear in App.js wiring (providers now wrapped by AppProviders). SystemMonitoring removed per UX.
-      ['AppProviders','NavigationBar','ProgressIndicator'].forEach((c) => {
+      ['AppProviders', 'NavigationBar', 'TooltipManager'].forEach((c) => {
         expect(appContent).toContain(c);
       });
       // Undo/Redo toolbar lives in its own file; ensure it exists there

--- a/test/settings-service.test.js
+++ b/test/settings-service.test.js
@@ -1,0 +1,29 @@
+const fs = require('fs').promises;
+const path = require('path');
+const os = require('os');
+const fsSync = require('fs');
+const { app } = require('electron');
+
+const SettingsService = require('../src/main/services/SettingsService');
+
+describe('SettingsService atomic save', () => {
+  test('interrupted write leaves original file intact', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'settings-test-'));
+    app.getPath.mockReturnValue(tempDir);
+
+    const service = new SettingsService();
+    const filePath = path.join(tempDir, 'settings.json');
+    await fs.writeFile(filePath, JSON.stringify({ theme: 'dark' }, null, 2));
+
+    const renameMock = jest
+      .spyOn(fsSync.promises, 'rename')
+      .mockRejectedValueOnce(new Error('simulated failure'));
+
+    await expect(service.save({ theme: 'light' })).rejects.toThrow('simulated failure');
+
+    const content = JSON.parse(await fs.readFile(filePath, 'utf-8'));
+    expect(content.theme).toBe('dark');
+
+    renameMock.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- use backupAndReplace for atomic writes in SettingsService
- add regression test for interrupted settings writes
- adjust React app test to current component wiring

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f829f4a388324ad7ba0c84fdec5dc