### PR TITLE
chore: tighten CSP and externalize inline styles

### DIFF
--- a/src/main/core/createWindow.js
+++ b/src/main/core/createWindow.js
@@ -53,16 +53,25 @@ function createMainWindow() {
     });
   }
 
-  win.webContents.session.webRequest.onHeadersReceived((details, callback) => {
-    callback({
-      responseHeaders: {
-        ...details.responseHeaders,
-        'Content-Security-Policy': [
-          "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' http://127.0.0.1:11434 http://localhost:11434 ws://localhost:*; object-src 'none'; base-uri 'self'; form-action 'self';"
-        ]
+    win.webContents.session.webRequest.onHeadersReceived((details, callback) => {
+      const ollamaHost = process.env.OLLAMA_HOST || 'http://127.0.0.1:11434';
+      let wsHost = '';
+      try {
+        const url = new URL(ollamaHost);
+        wsHost = url.protocol === 'https:' ? `wss://${url.host}` : `ws://${url.host}`;
+      } catch {
+        wsHost = '';
       }
+
+      const csp = `default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' ${ollamaHost} ${wsHost}; object-src 'none'; base-uri 'self'; form-action 'self';`;
+
+      callback({
+        responseHeaders: {
+          ...details.responseHeaders,
+          'Content-Security-Policy': [csp]
+        }
+      });
     });
-  });
 
   win.once('ready-to-show', () => {
     win.show();

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -4,18 +4,18 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>StratoSort - AI-Powered File Organization</title>
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' http://localhost:11434 ws://localhost:*; object-src 'none'; base-uri 'self'; form-action 'self';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' http://localhost:11434 ws://localhost:*; object-src 'none'; base-uri 'self'; form-action 'self';">
     <!-- Enhanced CSP: Allows Ollama API calls and WebSocket connections for HMR -->
 </head>
 <body>
     <!-- Initial loading screen -->
-    <div id="initial-loading" style="height: 100vh; display: flex; align-items: center; justify-content: center; font-family: 'Inter', -apple-system, sans-serif;">
-        <section style="text-align: center; max-width: 400px;">
-            <div class="animate-float" style="font-size: 48px; margin-bottom: 16px;" aria-hidden="true">🚀</div>
-            <h1 style="color: #334155; margin: 0; font-size: 24px; font-weight: 600;">Loading StratoSort</h1>
-            <p style="color: #64748B; margin: 8px 0 0 0; font-size: 14px;">AI-Powered File Organization</p>
-            <div style="margin-top: 24px;">
-                <div class="loading-spinner" style="width: 24px; height: 24px; border: 2px solid #E2E8F0; border-top: 2px solid #2563EB; border-radius: 50%; animation: spin 1s linear infinite; margin: 0 auto;"></div>
+    <div id="initial-loading" class="initial-loading">
+        <section class="initial-section">
+            <div class="initial-icon animate-float" aria-hidden="true">🚀</div>
+            <h1 class="initial-title">Loading StratoSort</h1>
+            <p class="initial-subtitle">AI-Powered File Organization</p>
+            <div class="initial-spinner-wrapper">
+                <div class="loading-spinner"></div>
             </div>
         </section>
     </div>
@@ -23,26 +23,6 @@
     <!-- React root container (must be empty for React to work) -->
     <div id="root"></div>
     
-    <style>
-        @keyframes spin {
-            0% { transform: rotate(0deg); }
-            100% { transform: rotate(360deg); }
-        }
-        
-        @keyframes float {
-            0%, 100% { transform: translateY(0px); }
-            50% { transform: translateY(-6px); }
-        }
-        
-        .animate-float {
-            animation: float 3s ease-in-out infinite;
-        }
-        
-        .loading-spinner {
-            animation: spin 1s linear infinite;
-        }
-    </style>
-    
     <!-- Webpack will inject the script tags automatically -->
 </body>
-</html> 
+</html>

--- a/src/renderer/tailwind.css
+++ b/src/renderer/tailwind.css
@@ -781,10 +781,53 @@ select:focus {
   .glass-strong {
     @apply bg-white border-system-gray-900 backdrop-blur-none;
   }
-  
+
   .hc-card-border { @apply border-system-gray-900; }
-  
+
   .btn-primary {
     @apply bg-system-gray-900 text-white border-2 border-system-gray-900;
+  }
+}
+
+@keyframes float {
+  0%, 100% {
+    transform: translateY(0px);
+  }
+  50% {
+    transform: translateY(-6px);
+  }
+}
+
+@layer components {
+  .animate-float {
+    animation: float 3s ease-in-out infinite;
+  }
+
+  .initial-loading {
+    @apply h-screen flex items-center justify-center font-sans;
+  }
+
+  .initial-section {
+    @apply text-center max-w-[400px];
+  }
+
+  .initial-icon {
+    @apply text-[48px] mb-4;
+  }
+
+  .initial-title {
+    @apply text-[#334155] m-0 text-2xl font-semibold;
+  }
+
+  .initial-subtitle {
+    @apply text-[#64748B] mt-2 text-sm;
+  }
+
+  .initial-spinner-wrapper {
+    @apply mt-6;
+  }
+
+  .loading-spinner {
+    @apply w-6 h-6 border-2 border-[#E2E8F0] border-t-[#2563EB] rounded-full mx-auto animate-spin;
   }
 }


### PR DESCRIPTION
## Summary
- move renderer inline styles into tailwind.css
- derive CSP connect-src from `OLLAMA_HOST`
- drop `'unsafe-inline'` from style-src directives

## Testing
- `npm test` *(fails: Expected substring: "ProgressIndicator")*
- `npm run build:dev`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f8291cde083249ecb34f7ab797bc2