### PR TITLE
refactor: use centralized logger instead of console

### DIFF
--- a/src/main/analysis/ollamaDocumentAnalysis.js
+++ b/src/main/analysis/ollamaDocumentAnalysis.js
@@ -49,7 +49,7 @@ async function analyzeDocumentFile(filePath, smartFolders = []) {
   try {
     const connectionCheck = await modelVerifier.checkOllamaConnection();
     if (!connectionCheck.connected) {
-      console.warn(`[ANALYSIS-FALLBACK] Ollama unavailable (${connectionCheck.error}). Using filename-based analysis for ${fileName}.`);
+      logger.warn(`[ANALYSIS-FALLBACK] Ollama unavailable (${connectionCheck.error}). Using filename-based analysis for ${fileName}.`);
       const intelligentCategory = getIntelligentCategory(fileName, fileExtension, smartFolders);
       const intelligentKeywords = getIntelligentKeywords(fileName, fileExtension);
       return {
@@ -64,7 +64,7 @@ async function analyzeDocumentFile(filePath, smartFolders = []) {
       };
     }
   } catch (error) {
-    console.error('Pre-flight verification failed:', error.message);
+    logger.error('Pre-flight verification failed:', error.message);
     const intelligentCategory = getIntelligentCategory(fileName, fileExtension, smartFolders);
     const intelligentKeywords = getIntelligentKeywords(fileName, fileExtension);
     return {

--- a/src/main/analysis/ollamaImageAnalysis.js
+++ b/src/main/analysis/ollamaImageAnalysis.js
@@ -271,7 +271,7 @@ async function analyzeImageFile(filePath, smartFolders = []) {
     };
 
   } catch (error) {
-    console.error(`Error processing image ${filePath}:`, error.message);
+    logger.error(`Error processing image ${filePath}:`, error.message);
     return {
       error: `Failed to process image: ${error.message}`,
       category: 'error',
@@ -309,7 +309,7 @@ async function extractTextFromImage(filePath) {
     
     return null;
   } catch (error) {
-    console.error('Error extracting text from image:', error.message);
+    logger.error('Error extracting text from image:', error.message);
     return null;
   }
 }

--- a/src/main/errors/ErrorHandler.js
+++ b/src/main/errors/ErrorHandler.js
@@ -7,6 +7,7 @@ const { app, dialog, BrowserWindow } = require('electron');
 const fs = require('fs').promises;
 const path = require('path');
 const { ERROR_TYPES } = require('../../shared/constants');
+const { logger } = require('../../shared/logger');
 
 class ErrorHandler {
   constructor() {
@@ -31,7 +32,7 @@ class ErrorHandler {
       this.isInitialized = true;
       await this.log('info', 'ErrorHandler initialized successfully');
     } catch (error) {
-      console.error('Failed to initialize ErrorHandler:', error);
+      logger.error('Failed to initialize ErrorHandler:', error);
     }
   }
 
@@ -145,7 +146,7 @@ class ErrorHandler {
    * Handle critical errors that may crash the app
    */
   async handleCriticalError(message, error) {
-    console.error('CRITICAL ERROR:', message, error);
+    logger.error('CRITICAL ERROR:', message, error);
     
     // Log to file
     await this.log('critical', message, {
@@ -198,7 +199,8 @@ class ErrorHandler {
    */
   async log(level, message, data = {}) {
     if (!this.isInitialized) {
-      console.log(`[${level.toUpperCase()}] ${message}`, data);
+      const logMethod = level === 'critical' ? logger.error : logger[level] || logger.info;
+      logMethod(`[${level.toUpperCase()}] ${message}`, data);
       return;
     }
 
@@ -213,7 +215,7 @@ class ErrorHandler {
       const logLine = JSON.stringify(logEntry) + '\n';
       await fs.appendFile(this.currentLogFile, logLine);
     } catch (error) {
-      console.error('Failed to write to log file:', error);
+      logger.error('Failed to write to log file:', error);
     }
   }
 
@@ -237,7 +239,7 @@ class ErrorHandler {
       
       return errors;
     } catch (error) {
-      console.error('Failed to read error log:', error);
+      logger.error('Failed to read error log:', error);
       return [];
     }
   }
@@ -263,7 +265,7 @@ class ErrorHandler {
         }
       }
     } catch (error) {
-      console.error('Failed to cleanup logs:', error);
+      logger.error('Failed to cleanup logs:', error);
     }
   }
 }

--- a/src/main/folderScanner.js
+++ b/src/main/folderScanner.js
@@ -1,5 +1,6 @@
 const fs = require('fs').promises;
 const path = require('path');
+const { logger } = require('../shared/logger');
 
 const DEFAULT_IGNORE_PATTERNS = [
   '.DS_Store',
@@ -45,7 +46,7 @@ async function scanDirectory(dirPath, ignorePatterns = DEFAULT_IGNORE_PATTERNS) 
       items.push(itemInfo);
     }
   } catch (error) {
-    console.error(`Error scanning directory ${dirPath}:`, error);
+    logger.error(`Error scanning directory ${dirPath}:`, error);
     // Optionally, rethrow or return a specific error structure
     if (error.code === 'EACCES' || error.code === 'EPERM') {
       // Handle permission errors gracefully, e.g., by skipping the directory

--- a/src/main/ollamaUtils.js
+++ b/src/main/ollamaUtils.js
@@ -3,6 +3,7 @@ const { Ollama } = require('ollama');
 const { app } = require('electron');
 const fs = require('fs').promises;
 const path = require('path');
+const { logger } = require('../shared/logger');
 
 // Path for storing Ollama configuration, e.g., selected model
 const getOllamaConfigPath = () => {
@@ -51,9 +52,9 @@ async function setOllamaModel(modelName) {
       // Keep legacy field for backward compatibility
       selectedModel: modelName
     });
-    console.log(`[OLLAMA] Text model set to: ${modelName} and saved.`);
+    logger.info(`[OLLAMA] Text model set to: ${modelName} and saved.`);
   } catch (error) {
-    console.error(`[OLLAMA] Error saving text model selection:`, error);
+    logger.error(`[OLLAMA] Error saving text model selection:`, error);
   }
 }
 
@@ -65,9 +66,9 @@ async function setOllamaVisionModel(modelName) {
       ...current,
       selectedVisionModel: modelName
     });
-    console.log(`[OLLAMA] Vision model set to: ${modelName} and saved.`);
+    logger.info(`[OLLAMA] Vision model set to: ${modelName} and saved.`);
   } catch (error) {
-    console.error(`[OLLAMA] Error saving vision model selection:`, error);
+    logger.error(`[OLLAMA] Error saving vision model selection:`, error);
   }
 }
 
@@ -79,9 +80,9 @@ async function setOllamaEmbeddingModel(modelName) {
       ...current,
       selectedEmbeddingModel: modelName
     });
-    console.log(`[OLLAMA] Embedding model set to: ${modelName} and saved.`);
+    logger.info(`[OLLAMA] Embedding model set to: ${modelName} and saved.`);
   } catch (error) {
-    console.error(`[OLLAMA] Error saving embedding model selection:`, error);
+    logger.error(`[OLLAMA] Error saving embedding model selection:`, error);
   }
 }
 
@@ -97,10 +98,10 @@ async function setOllamaHost(host) {
       ollamaInstance = new Ollama({ host: ollamaHost });
       const current = await loadOllamaConfig();
       await saveOllamaConfig({ ...current, host: ollamaHost });
-      console.log(`[OLLAMA] Host set to: ${ollamaHost}`);
+      logger.info(`[OLLAMA] Host set to: ${ollamaHost}`);
     }
   } catch (error) {
-    console.error('[OLLAMA] Error setting host:', error);
+    logger.error('[OLLAMA] Error setting host:', error);
   }
 }
 
@@ -113,26 +114,26 @@ async function loadOllamaConfig() {
     // Support legacy and new keys
     if (config.selectedTextModel || config.selectedModel) {
       selectedTextModel = config.selectedTextModel || config.selectedModel;
-      console.log(`[OLLAMA] Loaded selected text model: ${selectedTextModel}`);
+      logger.info(`[OLLAMA] Loaded selected text model: ${selectedTextModel}`);
     }
     if (config.selectedVisionModel) {
       selectedVisionModel = config.selectedVisionModel;
-      console.log(`[OLLAMA] Loaded selected vision model: ${selectedVisionModel}`);
+      logger.info(`[OLLAMA] Loaded selected vision model: ${selectedVisionModel}`);
     }
     if (config.selectedEmbeddingModel) {
       selectedEmbeddingModel = config.selectedEmbeddingModel;
-      console.log(`[OLLAMA] Loaded selected embedding model: ${selectedEmbeddingModel}`);
+      logger.info(`[OLLAMA] Loaded selected embedding model: ${selectedEmbeddingModel}`);
     }
     if (config.host) {
       ollamaHost = config.host;
       ollamaInstance = new Ollama({ host: ollamaHost });
-      console.log(`[OLLAMA] Loaded host: ${ollamaHost}`);
+      logger.info(`[OLLAMA] Loaded host: ${ollamaHost}`);
     }
     return config;
   } catch (error) {
     // It's okay if the file doesn't exist on first run
     if (error.code !== 'ENOENT') {
-      console.error('[OLLAMA] Error loading Ollama config:', error);
+      logger.error('[OLLAMA] Error loading Ollama config:', error);
     }
     // Fallback to a default model or leave as null if no configuration is found
     // You might want to fetch available models and pick one if ollamaModel is still null
@@ -157,12 +158,12 @@ async function loadOllamaConfig() {
                      foundModel = modelsResponse.models[0].name; // Fallback to the first model
                 }
                 await setOllamaModel(foundModel);
-                console.log(`[OLLAMA] No saved text model found, defaulted to: ${selectedTextModel}`);
+                logger.info(`[OLLAMA] No saved text model found, defaulted to: ${selectedTextModel}`);
             } else {
-                console.warn('[OLLAMA] No models available from Ollama server.');
+                logger.warn('[OLLAMA] No models available from Ollama server.');
             }
         } catch (listError) {
-            console.error('[OLLAMA] Error fetching model list during initial load:', listError);
+            logger.error('[OLLAMA] Error fetching model list during initial load:', listError);
         }
     }
     return { selectedTextModel, selectedVisionModel, host: ollamaHost };
@@ -175,7 +176,7 @@ async function saveOllamaConfig(config) {
     const filePath = getOllamaConfigPath();
     await fs.writeFile(filePath, JSON.stringify(config, null, 2));
   } catch (error) {
-    console.error('[OLLAMA] Error saving Ollama config:', error);
+    logger.error('[OLLAMA] Error saving Ollama config:', error);
     throw error; // Re-throw to indicate save failure
   }
 }

--- a/src/main/services/AnalysisHistoryService.js
+++ b/src/main/services/AnalysisHistoryService.js
@@ -2,6 +2,7 @@ const fs = require('fs').promises;
 const path = require('path');
 const { app } = require('electron');
 const crypto = require('crypto');
+const { logger } = require('../../shared/logger');
 
 class AnalysisHistoryService {
   constructor() {
@@ -28,9 +29,9 @@ class AnalysisHistoryService {
       await this.loadHistory();
       await this.loadIndex();
       this.initialized = true;
-      console.log('AnalysisHistoryService initialized successfully');
+      logger.info('AnalysisHistoryService initialized successfully');
     } catch (error) {
-      console.error('Failed to initialize AnalysisHistoryService:', error);
+      logger.error('Failed to initialize AnalysisHistoryService:', error);
       await this.createDefaultStructures();
     }
   }
@@ -392,7 +393,7 @@ class AnalysisHistoryService {
     }
     
     if (removedCount > 0) {
-      console.log(`Removed ${removedCount} expired analysis entries`);
+      logger.info(`Removed ${removedCount} expired analysis entries`);
       await this.saveHistory();
       await this.saveIndex();
     }
@@ -426,7 +427,7 @@ class AnalysisHistoryService {
 
   async migrateHistory() {
     // Future migration logic for schema changes
-    console.log('Schema migration not yet implemented');
+    logger.info('Schema migration not yet implemented');
   }
 
   async createDefaultStructures() {

--- a/src/main/services/ModelManager.js
+++ b/src/main/services/ModelManager.js
@@ -7,6 +7,7 @@ const { Ollama } = require('ollama');
 const { app } = require('electron');
 const fs = require('fs').promises;
 const path = require('path');
+const { logger } = require('../../shared/logger');
 
 class ModelManager {
   constructor(host = 'http://127.0.0.1:11434') {
@@ -39,7 +40,7 @@ class ModelManager {
    */
   async initialize() {
     try {
-      console.log('[MODEL-MANAGER] Initializing...');
+      logger.info('[MODEL-MANAGER] Initializing...');
       
       // Load saved configuration
       await this.loadConfig();
@@ -50,10 +51,10 @@ class ModelManager {
       // Ensure we have a working model
       await this.ensureWorkingModel();
       
-      console.log(`[MODEL-MANAGER] Initialized with model: ${this.selectedModel}`);
+      logger.info(`[MODEL-MANAGER] Initialized with model: ${this.selectedModel}`);
       return true;
     } catch (error) {
-      console.error('[MODEL-MANAGER] Initialization failed:', error);
+      logger.error('[MODEL-MANAGER] Initialization failed:', error);
       return false;
     }
   }
@@ -71,10 +72,10 @@ class ModelManager {
         this.analyzeModelCapabilities(model);
       }
       
-      console.log(`[MODEL-MANAGER] Discovered ${this.availableModels.length} models`);
+      logger.info(`[MODEL-MANAGER] Discovered ${this.availableModels.length} models`);
       return this.availableModels;
     } catch (error) {
-      console.error('[MODEL-MANAGER] Failed to discover models:', error);
+      logger.error('[MODEL-MANAGER] Failed to discover models:', error);
       this.availableModels = [];
       return [];
     }
@@ -128,7 +129,7 @@ class ModelManager {
     if (this.selectedModel) {
       const modelExists = this.availableModels.some(m => m.name === this.selectedModel);
       if (modelExists && await this.testModel(this.selectedModel)) {
-        console.log(`[MODEL-MANAGER] Using existing model: ${this.selectedModel}`);
+        logger.info(`[MODEL-MANAGER] Using existing model: ${this.selectedModel}`);
         return this.selectedModel;
       }
     }
@@ -158,7 +159,7 @@ class ModelManager {
       );
       
       if (model && await this.testModel(model.name)) {
-        console.log(`[MODEL-MANAGER] Selected preferred model: ${model.name}`);
+        logger.info(`[MODEL-MANAGER] Selected preferred model: ${model.name}`);
         return model.name;
       }
     }
@@ -168,7 +169,7 @@ class ModelManager {
       const capabilities = this.modelCapabilities.get(model.name);
       if (capabilities && (capabilities.text || capabilities.chat)) {
         if (await this.testModel(model.name)) {
-          console.log(`[MODEL-MANAGER] Selected fallback model: ${model.name}`);
+          logger.info(`[MODEL-MANAGER] Selected fallback model: ${model.name}`);
           return model.name;
         }
       }
@@ -177,7 +178,7 @@ class ModelManager {
     // Last resort: try the first available model
     const firstModel = this.availableModels[0];
     if (await this.testModel(firstModel.name)) {
-      console.log(`[MODEL-MANAGER] Selected first available model: ${firstModel.name}`);
+      logger.info(`[MODEL-MANAGER] Selected first available model: ${firstModel.name}`);
       return firstModel.name;
     }
 
@@ -189,7 +190,7 @@ class ModelManager {
    */
   async testModel(modelName, timeout = 10000) {
     try {
-      console.log(`[MODEL-MANAGER] Testing model: ${modelName}`);
+      logger.info(`[MODEL-MANAGER] Testing model: ${modelName}`);
       
       const { buildOllamaOptions } = require('./PerformanceService');
       const perfOptions = await buildOllamaOptions('text');
@@ -208,10 +209,10 @@ class ModelManager {
       );
 
       await Promise.race([testPromise, timeoutPromise]);
-      console.log(`[MODEL-MANAGER] Model ${modelName} is working`);
+      logger.info(`[MODEL-MANAGER] Model ${modelName} is working`);
       return true;
     } catch (error) {
-      console.log(`[MODEL-MANAGER] Model ${modelName} failed test: ${error.message}`);
+      logger.info(`[MODEL-MANAGER] Model ${modelName} failed test: ${error.message}`);
       return false;
     }
   }
@@ -267,7 +268,7 @@ class ModelManager {
 
     this.selectedModel = modelName;
     await this.saveConfig();
-    console.log(`[MODEL-MANAGER] Selected model set to: ${modelName}`);
+    logger.info(`[MODEL-MANAGER] Selected model set to: ${modelName}`);
   }
 
   /**
@@ -302,7 +303,7 @@ class ModelManager {
 
     for (const modelName of modelsToTry) {
       try {
-        console.log(`[MODEL-MANAGER] Attempting generation with: ${modelName}`);
+        logger.info(`[MODEL-MANAGER] Attempting generation with: ${modelName}`);
         
         const { buildOllamaOptions } = require('./PerformanceService');
         const perfOptions = await buildOllamaOptions('text');
@@ -325,7 +326,7 @@ class ModelManager {
           };
         }
       } catch (error) {
-        console.log(`[MODEL-MANAGER] Model ${modelName} failed: ${error.message}`);
+        logger.info(`[MODEL-MANAGER] Model ${modelName} failed: ${error.message}`);
         continue;
       }
     }
@@ -341,10 +342,10 @@ class ModelManager {
       const data = await fs.readFile(this.configPath, 'utf-8');
       const config = JSON.parse(data);
       this.selectedModel = config.selectedModel || null;
-      console.log(`[MODEL-MANAGER] Loaded config: ${this.selectedModel}`);
+      logger.info(`[MODEL-MANAGER] Loaded config: ${this.selectedModel}`);
     } catch (error) {
       if (error.code !== 'ENOENT') {
-        console.error('[MODEL-MANAGER] Error loading config:', error);
+        logger.error('[MODEL-MANAGER] Error loading config:', error);
       }
     }
   }
@@ -360,7 +361,7 @@ class ModelManager {
       };
       await fs.writeFile(this.configPath, JSON.stringify(config, null, 2));
     } catch (error) {
-      console.error('[MODEL-MANAGER] Error saving config:', error);
+      logger.error('[MODEL-MANAGER] Error saving config:', error);
     }
   }
 

--- a/src/main/services/ModelVerifier.js
+++ b/src/main/services/ModelVerifier.js
@@ -6,6 +6,7 @@
 const { Ollama } = require('ollama');
 const { ModelMissingError, OllamaConnectionError } = require('../errors/AnalysisError');
 const { DEFAULT_AI_MODELS } = require('../../shared/constants');
+const { logger } = require('../../shared/logger');
 
 class ModelVerifier {
   constructor() {
@@ -58,7 +59,7 @@ class ModelVerifier {
   }
 
   async verifyEssentialModels() {
-    console.log('[ModelVerifier] Checking essential models...');
+    logger.info('[ModelVerifier] Checking essential models...');
     
     const connectionCheck = await this.checkOllamaConnection();
     if (!connectionCheck.connected) {
@@ -103,8 +104,8 @@ class ModelVerifier {
     const whisperVariants = ['whisper', 'whisper:base', 'whisper:small', 'whisper:medium', 'whisper:large'];
     const hasWhisper = installedModelNames.some(installed => installed.startsWith('whisper'));
 
-    console.log(`[ModelVerifier] Found ${availableModels.length}/${this.essentialModels.length} essential models`);
-    console.log(`[ModelVerifier] Whisper available: ${hasWhisper}`);
+    logger.info(`[ModelVerifier] Found ${availableModels.length}/${this.essentialModels.length} essential models`);
+    logger.info(`[ModelVerifier] Whisper available: ${hasWhisper}`);
 
     return {
       success: missingModels.length === 0,
@@ -179,7 +180,7 @@ class ModelVerifier {
   }
 
   async testModelFunctionality() {
-    console.log('[ModelVerifier] Testing model functionality...');
+    logger.info('[ModelVerifier] Testing model functionality...');
     
     const tests = [];
 
@@ -253,7 +254,7 @@ class ModelVerifier {
     }
 
     const successfulTests = tests.filter(t => t.success).length;
-    console.log(`[ModelVerifier] ${successfulTests}/${tests.length} functionality tests passed`);
+    logger.info(`[ModelVerifier] ${successfulTests}/${tests.length} functionality tests passed`);
 
     return {
       success: successfulTests >= Math.ceil(tests.length * 0.5), // At least half should work

--- a/src/main/services/SettingsService.js
+++ b/src/main/services/SettingsService.js
@@ -1,6 +1,7 @@
 const { app } = require('electron');
 const fs = require('fs').promises;
 const path = require('path');
+const { logger } = require('../../shared/logger');
 
 class SettingsService {
   constructor() {
@@ -28,7 +29,7 @@ class SettingsService {
       return { ...this.defaults, ...parsed };
     } catch (err) {
       if (err && err.code !== 'ENOENT') {
-        console.warn('[SETTINGS] Failed to read settings, using defaults:', err.message);
+        logger.warn('[SETTINGS] Failed to read settings, using defaults:', err.message);
       }
       return { ...this.defaults };
     }

--- a/src/main/services/UndoRedoService.js
+++ b/src/main/services/UndoRedoService.js
@@ -1,6 +1,7 @@
 const fs = require('fs').promises;
 const path = require('path');
 const { app } = require('electron');
+const { logger } = require('../../shared/logger');
 
 class UndoRedoService {
   constructor() {
@@ -19,9 +20,9 @@ class UndoRedoService {
     try {
       await this.loadActions();
       this.initialized = true;
-      console.log('UndoRedoService initialized successfully');
+      logger.info('UndoRedoService initialized successfully');
     } catch (error) {
-      console.error('Failed to initialize UndoRedoService:', error);
+      logger.error('Failed to initialize UndoRedoService:', error);
       this.actions = [];
       this.currentIndex = -1;
       this.initialized = true;
@@ -100,7 +101,7 @@ class UndoRedoService {
         message: `Undid: ${action.description}`
       };
     } catch (error) {
-      console.error('Failed to undo action:', error);
+      logger.error('Failed to undo action:', error);
       throw new Error(`Failed to undo action: ${error.message}`);
     }
   }
@@ -124,7 +125,7 @@ class UndoRedoService {
         message: `Redid: ${action.description}`
       };
     } catch (error) {
-      console.error('Failed to redo action:', error);
+      logger.error('Failed to redo action:', error);
       throw new Error(`Failed to redo action: ${error.message}`);
     }
   }
@@ -164,7 +165,7 @@ class UndoRedoService {
           await fs.rmdir(action.data.folderPath);
         } catch (error) {
           // Folder might not be empty, try to restore to original state
-          console.warn('Could not remove folder, might contain files:', error.message);
+          logger.warn('Could not remove folder, might contain files:', error.message);
         }
         break;
         

--- a/src/preload/preload.js
+++ b/src/preload/preload.js
@@ -1,7 +1,8 @@
 const { contextBridge, ipcRenderer } = require('electron');
 const path = require('path');
+const { logger } = require('../shared/logger');
 
-console.log('[PRELOAD] Secure preload script loaded');
+logger.info('[PRELOAD] Secure preload script loaded');
 
 // Import centralized IPC channel map using an absolute path to avoid resolution issues when the preload is bundled or moved
 const constantsPath = path.resolve(__dirname, '..', 'shared', 'constants.js');
@@ -71,7 +72,7 @@ class SecureIPCManager {
     try {
       // Channel validation
       if (!ALL_SEND_CHANNELS.includes(channel)) {
-        console.warn(`[PRELOAD] Blocked invoke to unauthorized channel: ${channel}`);
+        logger.warn(`[PRELOAD] Blocked invoke to unauthorized channel: ${channel}`);
         throw new Error(`Unauthorized IPC channel: ${channel}`);
       }
 
@@ -81,7 +82,7 @@ class SecureIPCManager {
       // Argument sanitization
       const sanitizedArgs = this.sanitizeArguments(args);
 
-      console.log(`[PRELOAD] Secure invoke: ${channel}`, sanitizedArgs.length > 0 ? '[with args]' : '');
+      logger.info(`[PRELOAD] Secure invoke: ${channel}`, sanitizedArgs.length > 0 ? '[with args]' : '');
       
       const result = await ipcRenderer.invoke(channel, ...sanitizedArgs);
       
@@ -89,7 +90,7 @@ class SecureIPCManager {
       return this.validateResult(result, channel);
       
     } catch (error) {
-      console.error(`[PRELOAD] IPC invoke error for ${channel}:`, error.message);
+      logger.error(`[PRELOAD] IPC invoke error for ${channel}:`, error.message);
       throw new Error(`IPC Error: ${error.message}`);
     }
   }
@@ -99,7 +100,7 @@ class SecureIPCManager {
    */
   safeOn(channel, callback) {
     if (!ALLOWED_RECEIVE_CHANNELS.includes(channel)) {
-      console.warn(`[PRELOAD] Blocked listener on unauthorized channel: ${channel}`);
+      logger.warn(`[PRELOAD] Blocked listener on unauthorized channel: ${channel}`);
       return () => {};
     }
 
@@ -107,7 +108,7 @@ class SecureIPCManager {
       try {
         // Validate event source
         if (!this.validateEventSource(event)) {
-          console.warn(`[PRELOAD] Rejected event from invalid source on channel: ${channel}`);
+          logger.warn(`[PRELOAD] Rejected event from invalid source on channel: ${channel}`);
           return;
         }
 
@@ -120,13 +121,13 @@ class SecureIPCManager {
           if (this.isValidSystemMetrics(data)) {
             callback(data);
           } else {
-            console.warn('[PRELOAD] Invalid system-metrics data rejected');
+            logger.warn('[PRELOAD] Invalid system-metrics data rejected');
           }
         } else {
           callback(...sanitizedArgs);
         }
       } catch (error) {
-        console.error(`[PRELOAD] Error in ${channel} event handler:`, error);
+        logger.error(`[PRELOAD] Error in ${channel} event handler:`, error);
       }
     };
 
@@ -229,7 +230,7 @@ class SecureIPCManager {
       ipcRenderer.removeListener(channel, callback);
     }
     this.activeListeners.clear();
-    console.log('[PRELOAD] All IPC listeners cleaned up');
+    logger.info('[PRELOAD] All IPC listeners cleaned up');
   }
 }
 
@@ -361,14 +362,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
 contextBridge.exposeInMainWorld('electron', {
   ipcRenderer: {
     invoke: (channel, ...args) => {
-      console.warn('[PRELOAD] Using deprecated electron.ipcRenderer.invoke - migrate to window.electronAPI');
+      logger.warn('[PRELOAD] Using deprecated electron.ipcRenderer.invoke - migrate to window.electronAPI');
       return secureIPC.safeInvoke(channel, ...args);
     },
     on: (channel, callback) => {
-      console.warn('[PRELOAD] Using deprecated electron.ipcRenderer.on - migrate to window.electronAPI.events');
+      logger.warn('[PRELOAD] Using deprecated electron.ipcRenderer.on - migrate to window.electronAPI.events');
       return secureIPC.safeOn(channel, callback);
     }
   }
 });
 
-console.log('[PRELOAD] Secure context bridge exposed with structured API'); 
+logger.info('[PRELOAD] Secure context bridge exposed with structured API');

--- a/src/renderer/components/SettingsPanel.jsx
+++ b/src/renderer/components/SettingsPanel.jsx
@@ -6,6 +6,7 @@ import Input from './ui/Input';
 import Textarea from './ui/Textarea';
 import Select from './ui/Select';
 import Collapsible from './ui/Collapsible';
+import { logger } from '../../shared/logger';
 
 function SettingsPanel() {
   const { actions } = usePhase();
@@ -56,7 +57,7 @@ function SettingsPanel() {
         setSettings(prev => ({ ...prev, ...savedSettings }));
       }
     } catch (error) {
-      console.error('Failed to load settings:', error);
+      logger.error('Failed to load settings:', error);
     }
   };
 
@@ -82,7 +83,7 @@ function SettingsPanel() {
         }));
       }
     } catch (error) {
-      console.error('Failed to load Ollama models:', error);
+      logger.error('Failed to load Ollama models:', error);
       setOllamaModelLists({ text: [], vision: [], embedding: [], all: [] });
     } finally {
       setIsRefreshingModels(false);
@@ -96,7 +97,7 @@ function SettingsPanel() {
       addNotification('Settings saved successfully!', 'success');
       actions.toggleSettings();
     } catch (error) {
-      console.error('Failed to save settings:', error);
+      logger.error('Failed to save settings:', error);
       addNotification('Failed to save settings', 'error');
     } finally {
       setIsSaving(false);

--- a/src/renderer/components/SystemMonitoring.jsx
+++ b/src/renderer/components/SystemMonitoring.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { logger } from '../../shared/logger';
 
 function SystemMonitoring() {
   const [systemMetrics, setSystemMetrics] = useState({
@@ -21,11 +22,11 @@ function SystemMonitoring() {
             const updatedMetrics = await window.electronAPI.system.getMetrics();
             setSystemMetrics(updatedMetrics);
           } catch (error) {
-            console.warn('Failed to update system metrics:', error);
+            logger.warn('Failed to update system metrics:', error);
           }
         }, 5000);
       } catch (error) {
-        console.error('Failed to start system monitoring:', error);
+        logger.error('Failed to start system monitoring:', error);
         setIsMonitoring(false);
       }
     };

--- a/src/renderer/components/UndoRedoSystem.jsx
+++ b/src/renderer/components/UndoRedoSystem.jsx
@@ -1,6 +1,7 @@
 // Undo/Redo System - Implementing Shneiderman's Golden Rule #6: Action Reversal Infrastructure
 import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
 import { ConfirmModal } from './Modal';
+import { logger } from '../../shared/logger';
 
 // Undo/Redo Context
 const UndoRedoContext = createContext();
@@ -9,15 +10,15 @@ const UndoRedoContext = createContext();
 function useSimpleNotifications() {
   return {
     showSuccess: (title, description) => {
-      console.log(`✅ ${title}: ${description}`);
+      logger.info(`✅ ${title}: ${description}`);
       // Could integrate with window.electronAPI for toast notifications if available
     },
     showError: (title, description) => {
-      console.error(`❌ ${title}: ${description}`);
+      logger.error(`❌ ${title}: ${description}`);
       // Could integrate with window.electronAPI for toast notifications if available  
     },
     showInfo: (title, description) => {
-      console.log(`ℹ️ ${title}: ${description}`);
+      logger.info(`ℹ️ ${title}: ${description}`);
       // Could integrate with window.electronAPI for toast notifications if available
     }
   };

--- a/src/renderer/contexts/NotificationContext.jsx
+++ b/src/renderer/contexts/NotificationContext.jsx
@@ -1,5 +1,6 @@
 import React, { createContext, useCallback, useContext, useEffect } from 'react';
 import { ToastContainer, useToast } from '../components/Toast';
+import { logger } from '../../shared/logger';
 
 const NotificationContext = createContext(null);
 
@@ -27,7 +28,7 @@ export function NotificationProvider({ children }) {
         else if (type === 'warning') showWarning(message, 4000);
         else showInfo(message, 3000);
       } catch (e) {
-        console.error('[Renderer] Failed to display app:error', e);
+        logger.error('[Renderer] Failed to display app:error', e);
       }
     });
 

--- a/src/renderer/contexts/PhaseContext.jsx
+++ b/src/renderer/contexts/PhaseContext.jsx
@@ -1,5 +1,6 @@
 import React, { createContext, useCallback, useContext, useEffect, useReducer } from 'react';
 import { PHASES, PHASE_TRANSITIONS, PHASE_METADATA, UI_WORKFLOW } from '../../shared/constants';
+import { logger } from '../../shared/logger';
 
 function phaseReducer(state, action) {
   switch (action.type) {
@@ -7,7 +8,7 @@ function phaseReducer(state, action) {
       const { targetPhase, data = {} } = action.payload;
       const allowedTransitions = PHASE_TRANSITIONS[state.currentPhase] || [];
       if (targetPhase !== state.currentPhase && !allowedTransitions.includes(targetPhase)) {
-        console.warn(`Invalid transition from ${state.currentPhase} to ${targetPhase}`);
+        logger.warn(`Invalid transition from ${state.currentPhase} to ${targetPhase}`);
         return state;
       }
       return { ...state, currentPhase: targetPhase, phaseData: { ...state.phaseData, ...data } };
@@ -48,7 +49,7 @@ export function PhaseProvider({ children }) {
         }
       }
     } catch (error) {
-      console.error('Failed to load workflow state:', error);
+      logger.error('Failed to load workflow state:', error);
     }
   }, []);
 
@@ -60,7 +61,7 @@ export function PhaseProvider({ children }) {
           localStorage.setItem('stratosort_workflow_state', JSON.stringify(workflowState));
         }
       } catch (error) {
-        console.error('Failed to save workflow state:', error);
+        logger.error('Failed to save workflow state:', error);
       }
     };
     const timeoutId = setTimeout(save, UI_WORKFLOW.SAVE_DEBOUNCE_MS);

--- a/src/renderer/hooks/useKeyboardShortcuts.js
+++ b/src/renderer/hooks/useKeyboardShortcuts.js
@@ -3,6 +3,7 @@ import { usePhase } from '../contexts/PhaseContext';
 import { useUndoRedo } from '../components/UndoRedoSystem';
 import { useNotification } from '../contexts/NotificationContext';
 import { PHASES, PHASE_TRANSITIONS, PHASE_METADATA } from '../../shared/constants';
+import { logger } from '../../shared/logger';
 
 export function useKeyboardShortcuts() {
   const { actions, currentPhase, showSettings } = usePhase();
@@ -18,7 +19,7 @@ export function useKeyboardShortcuts() {
           try {
             addNotification('Use Ctrl+Z in organize phase for undo', 'info', 2000);
           } catch (error) {
-            console.error('Undo shortcut failed:', error);
+            logger.error('Undo shortcut failed:', error);
           }
         }
       }
@@ -30,7 +31,7 @@ export function useKeyboardShortcuts() {
           try {
             addNotification('Use Ctrl+Shift+Z in organize phase for redo', 'info', 2000);
           } catch (error) {
-            console.error('Redo shortcut failed:', error);
+            logger.error('Redo shortcut failed:', error);
           }
         }
       }

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -2,11 +2,12 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.js';
 import './tailwind.css';
+import { logger } from '../shared/logger';
 
 // Wait for DOM to be ready before initializing React
 function initializeApp() {
   try {
-    console.log('[RENDERER] Initializing React application...');
+    logger.info('[RENDERER] Initializing React application...');
     
     // Find the root container
     const container = document.getElementById('root');
@@ -14,7 +15,7 @@ function initializeApp() {
       throw new Error('Root container not found! Make sure there is a div with id="root" in the HTML.');
     }
     
-    console.log('[RENDERER] Root container found, creating React root...');
+    logger.info('[RENDERER] Root container found, creating React root...');
     
     // Create React root
     const root = createRoot(container);
@@ -32,10 +33,10 @@ function initializeApp() {
       </React.StrictMode>
     );
     
-    console.log('[RENDERER] React application initialized successfully');
+    logger.info('[RENDERER] React application initialized successfully');
     
   } catch (error) {
-    console.error('[RENDERER] Failed to initialize React application:', error);
+    logger.error('[RENDERER] Failed to initialize React application:', error);
     
     // Show error message in the initial loading screen
     const initialLoading = document.getElementById('initial-loading');

--- a/src/renderer/phases/DiscoverPhase.jsx
+++ b/src/renderer/phases/DiscoverPhase.jsx
@@ -7,6 +7,7 @@ import { Collapsible, Button, Input, Select } from '../components/ui';
 import AnalysisDetails from '../components/AnalysisDetails';
 import AnalysisHistoryModal from '../components/AnalysisHistoryModal';
 import { NamingSettings, SelectionControls, DragAndDropZone, AnalysisResultsList, AnalysisProgress } from '../components/discover';
+import { logger } from '../../shared/logger';
 
 function DiscoverPhase() {
   const { actions, phaseData } = usePhase();
@@ -55,7 +56,7 @@ function DiscoverPhase() {
       const isStuck = timeSinceActivity > 2 * 60 * 1000; // 2 minutes
       
       if (isStuck) {
-        console.log('[ANALYSIS] Detected stuck analysis state on mount, resetting...');
+        logger.info('[ANALYSIS] Detected stuck analysis state on mount, resetting...');
         // Don't restore stuck analysis state
         actions.setPhaseData('isAnalyzing', false);
         actions.setPhaseData('analysisProgress', { current: 0, total: 0 });
@@ -101,7 +102,7 @@ function DiscoverPhase() {
       const fiveMinutes = 5 * 60 * 1000;
       
       if (timeSinceActivity > fiveMinutes) {
-        console.log('[ANALYSIS] Auto-resetting stuck analysis state after 5 minutes of inactivity');
+        logger.info('[ANALYSIS] Auto-resetting stuck analysis state after 5 minutes of inactivity');
         addNotification('Detected stuck analysis state - auto-resetting', 'warning', 5000, 'analysis-auto-reset');
         actions.setPhaseData('isAnalyzing', false);
         actions.setPhaseData('analysisProgress', { current: 0, total: 0 });
@@ -124,7 +125,7 @@ function DiscoverPhase() {
       const twoMinutes = 2 * 60 * 1000;
       
       if (timeSinceActivity > twoMinutes) {
-        console.log('[ANALYSIS] Auto-resetting analysis with no progress after 2 minutes');
+        logger.info('[ANALYSIS] Auto-resetting analysis with no progress after 2 minutes');
         addNotification('Analysis stalled with no progress - auto-resetting', 'warning', 5000, 'analysis-stalled');
         actions.setPhaseData('isAnalyzing', false);
         actions.setPhaseData('analysisProgress', { current: 0, total: 0 });
@@ -475,7 +476,7 @@ function DiscoverPhase() {
   const analyzeFiles = async (files) => {
     if (!files || files.length === 0) return;
     
-    console.log('[ANALYSIS] analyzeFiles called with:', {
+    logger.info('[ANALYSIS] analyzeFiles called with:', {
       filesCount: files.length,
       isAnalyzing,
       analysisProgress,
@@ -486,7 +487,7 @@ function DiscoverPhase() {
     
     // Prevent multiple simultaneous analysis calls (silent)
     if (analysisLockRef.current || globalAnalysisActive) {
-      console.log('[ANALYSIS] Analysis already in progress, skipping duplicate call', {
+      logger.info('[ANALYSIS] Analysis already in progress, skipping duplicate call', {
         lockRef: analysisLockRef.current,
         globalState: globalAnalysisActive
       });
@@ -495,14 +496,14 @@ function DiscoverPhase() {
     
     // Additional check: prevent analysis if UI shows it's already running (silent)
     if (isAnalyzing) {
-      console.log('[ANALYSIS] UI shows analysis already in progress, skipping call');
+      logger.info('[ANALYSIS] UI shows analysis already in progress, skipping call');
       return;
     }
     
     // Set the lock immediately
     analysisLockRef.current = true;
     setGlobalAnalysisActive(true);
-    console.log('[ANALYSIS] Analysis lock acquired and global state set');
+    logger.info('[ANALYSIS] Analysis lock acquired and global state set');
     
     // Small delay to ensure lock is properly established
     await new Promise(resolve => setTimeout(resolve, 10));
@@ -510,14 +511,14 @@ function DiscoverPhase() {
     // Set a timeout to release the lock after 5 minutes (safety measure)
     const lockTimeout = setTimeout(() => {
       if (analysisLockRef.current) {
-        console.warn('[ANALYSIS] Analysis lock timeout reached, forcing release');
+        logger.warn('[ANALYSIS] Analysis lock timeout reached, forcing release');
         analysisLockRef.current = false;
       }
     }, 5 * 60 * 1000); // 5 minutes
     
     // Force reset any existing analysis state to ensure clean start
     if (isAnalyzing || analysisProgress.total > 0) {
-      console.log('[ANALYSIS] Force resetting existing analysis state for clean start');
+      logger.info('[ANALYSIS] Force resetting existing analysis state for clean start');
       setIsAnalyzing(false);
       setCurrentAnalysisFile('');
       setAnalysisProgress({ current: 0, total: 0 });
@@ -537,7 +538,7 @@ function DiscoverPhase() {
     actions.setPhaseData('analysisProgress', initialProgress);
     actions.setPhaseData('currentAnalysisFile', '');
     
-    console.log('[ANALYSIS] Started analysis with progress:', initialProgress);
+    logger.info('[ANALYSIS] Started analysis with progress:', initialProgress);
     
     // Set up progress heartbeat to prevent stuck states
     const heartbeatInterval = setInterval(() => {
@@ -553,7 +554,7 @@ function DiscoverPhase() {
           setAnalysisProgress(currentProgress);
           actions.setPhaseData('analysisProgress', currentProgress);
         } else {
-          console.warn('[ANALYSIS] Invalid heartbeat progress state detected, resetting analysis');
+          logger.warn('[ANALYSIS] Invalid heartbeat progress state detected, resetting analysis');
           clearInterval(heartbeatInterval);
           resetAnalysisState();
         }
@@ -610,7 +611,7 @@ function DiscoverPhase() {
             actions.setPhaseData('analysisProgress', progress);
             actions.setPhaseData('currentAnalysisFile', fileName);
           } else {
-            console.warn('[ANALYSIS] Invalid progress state detected, skipping update');
+            logger.warn('[ANALYSIS] Invalid progress state detected, skipping update');
           }
           
           const fileInfo = { ...file, size: file.size || 0, created: file.created, modified: file.modified };
@@ -674,10 +675,10 @@ function DiscoverPhase() {
             setAnalysisProgress(currentProgress);
             actions.setPhaseData('analysisProgress', currentProgress);
           } else {
-            console.warn('[ANALYSIS] Invalid batch progress state detected, skipping update');
+            logger.warn('[ANALYSIS] Invalid batch progress state detected, skipping update');
           }
         } catch (error) {
-          console.error('[ANALYSIS] Batch processing error:', error);
+          logger.error('[ANALYSIS] Batch processing error:', error);
           // Don't fail the entire analysis for batch errors
         }
       };
@@ -784,7 +785,7 @@ function DiscoverPhase() {
   };
 
   const forceReleaseAnalysisLock = () => {
-    console.log('[ANALYSIS] Manually releasing analysis lock');
+    logger.info('[ANALYSIS] Manually releasing analysis lock');
     analysisLockRef.current = false;
     setGlobalAnalysisActive(false);
     addNotification('Analysis lock manually released', 'info', 2000, 'analysis-reset');

--- a/src/renderer/phases/OrganizePhase.jsx
+++ b/src/renderer/phases/OrganizePhase.jsx
@@ -6,6 +6,7 @@ import { Collapsible, Button, Input, Select } from '../components/ui';
 import { StatusOverview, TargetFolderList, ReadyFileItem, BulkOperations, OrganizeProgress } from '../components/organize';
 import { UndoRedoToolbar, useUndoRedo } from '../components/UndoRedoSystem';
 import { createOrganizeBatchAction } from '../components/UndoRedoSystem';
+import { logger } from '../../shared/logger';
 
 function OrganizePhase() {
   const { actions, phaseData } = usePhase();
@@ -41,7 +42,7 @@ function OrganizePhase() {
           }
         }
       } catch (error) {
-        console.error('Failed to load smart folders in Organize phase:', error);
+        logger.error('Failed to load smart folders in Organize phase:', error);
       }
     };
     loadSmartFoldersIfMissing();

--- a/src/renderer/phases/SetupPhase.jsx
+++ b/src/renderer/phases/SetupPhase.jsx
@@ -6,6 +6,7 @@ import { useConfirmDialog } from '../hooks';
 import { Collapsible, Button, Input, Textarea } from '../components/ui';
 import { SmartFolderSkeleton } from '../components/LoadingSkeleton';
 import { SmartFolderItem } from '../components/setup';
+import { logger } from '../../shared/logger';
 
 function SetupPhase() {
   const { actions, phaseData } = usePhase();
@@ -31,7 +32,7 @@ function SetupPhase() {
       try {
         await Promise.all([loadSmartFolders(), loadDefaultLocation()]);
       } catch (error) {
-        console.error('Failed to initialize setup:', error);
+        logger.error('Failed to initialize setup:', error);
         showError('Failed to load setup data');
       } finally {
         setIsLoading(false);
@@ -63,7 +64,7 @@ function SetupPhase() {
         }
       }
     } catch (error) {
-      console.error('Failed to load default location:', error);
+      logger.error('Failed to load default location:', error);
     }
   };
 
@@ -76,7 +77,7 @@ function SetupPhase() {
         showInfo('Smart folders updated. Files may need re-analysis to match new folder structure.', 7000);
       }
     } catch (error) {
-      console.error('Failed to load smart folders:', error);
+      logger.error('Failed to load smart folders:', error);
       showError('Failed to load smart folders');
     }
   };
@@ -167,7 +168,7 @@ function SetupPhase() {
         showError(`❌ Failed to add folder: ${result.error}`);
       }
     } catch (error) {
-      console.error('Failed to add smart folder:', error);
+      logger.error('Failed to add smart folder:', error);
       showError('Failed to add smart folder');
     } finally {
       setIsAddingFolder(false);
@@ -196,7 +197,7 @@ function SetupPhase() {
         showError(`❌ Failed to update folder: ${result.error}`);
       }
     } catch (error) {
-      console.error('Failed to update folder:', error);
+      logger.error('Failed to update folder:', error);
       showError('Failed to update folder');
     } finally {
       setIsSavingEdit(false);
@@ -234,7 +235,7 @@ function SetupPhase() {
         showError(`❌ Failed to delete folder: ${result.error}`);
       }
     } catch (error) {
-      console.error('Failed to delete folder:', error);
+      logger.error('Failed to delete folder:', error);
       showError('❌ Failed to delete folder');
     } finally {
       setIsDeletingFolder(null);
@@ -250,7 +251,7 @@ function SetupPhase() {
         setNewFolderPath(res.folder);
       }
     } catch (error) {
-      console.error('Failed to browse folder:', error);
+      logger.error('Failed to browse folder:', error);
       showError('Failed to browse folder');
     }
   };
@@ -264,7 +265,7 @@ function SetupPhase() {
         showError(`Failed to open folder: ${result?.error || 'Unknown error'}`);
       }
     } catch (error) {
-      console.error('Failed to open folder:', error);
+      logger.error('Failed to open folder:', error);
       showError('Failed to open folder');
     }
   };
@@ -274,7 +275,7 @@ function SetupPhase() {
       await window.electronAPI.files.createFolder(folderPath);
       return { success: true };
     } catch (error) {
-      console.error('Failed to create folder:', error);
+      logger.error('Failed to create folder:', error);
       return { success: false, error: error.message };
     }
   };


### PR DESCRIPTION
## Summary
- replace `console.*` calls across main, renderer, and preload code with `logger` from `src/shared/logger.js`
- ensure all modules import and use the unified logger

## Testing
- `npm test` *(fails: Expected substring "ProgressIndicator")*

------
https://chatgpt.com/codex/tasks/task_e_689f82867be88324a7c6beeb8ca7d7da