### PR TITLE
chore: update auto-merge workflow for Dependabot

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,11 +1,17 @@
 name: Auto-merge Dependabot updates
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - synchronize
       - reopened
+
+permissions:
+  contents: write
+  pull-requests: write
+  checks: read
+  statuses: read
 
 jobs:
   automerge:
@@ -15,9 +21,10 @@ jobs:
       - name: Auto-approve Dependabot PR
         uses: hmarr/auto-approve-action@v4.0.0
         with:
-          github-token: '${{ secrets.GITHUB_TOKEN }}'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Auto-merge Dependabot PR
         uses: pascalgn/automerge-action@v0.16.3
         env:
-          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MERGE_METHOD: squash


### PR DESCRIPTION
- Changed the trigger for the auto-merge workflow to `pull_request_target` for enhanced security.
- Added permissions for contents, pull-requests, checks, and statuses to streamline the merging process.
- Updated the auto-approve and auto-merge actions to use the GitHub token without quotes and specified the merge method as squash.