### PR TITLE
Skip symlink entries during folder scan

### DIFF
--- a/src/main/folderScanner.js
+++ b/src/main/folderScanner.js
@@ -20,6 +20,9 @@ async function scanDirectory(
     const dirents = await fs.readdir(dirPath, { withFileTypes: true });
 
     for (const dirent of dirents) {
+      if (dirent.isSymbolicLink()) {
+        continue;
+      }
       const itemName = dirent.name;
       const itemPath = path.join(dirPath, itemName);
 

--- a/test/folderScanner.test.js
+++ b/test/folderScanner.test.js
@@ -1,0 +1,26 @@
+const fs = require('fs').promises;
+const path = require('path');
+const os = require('os');
+
+const { scanDirectory } = require('../src/main/folderScanner');
+
+describe('scanDirectory symlink handling', () => {
+  test('ignores symbolic links', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'scan-'));
+
+    const realFile = path.join(tmpDir, 'real.txt');
+    await fs.writeFile(realFile, 'content');
+
+    const symlinkPath = path.join(tmpDir, 'link.txt');
+    await fs.symlink(realFile, symlinkPath);
+
+    const items = await scanDirectory(tmpDir);
+
+    await fs.rm(tmpDir, { recursive: true, force: true });
+
+    const names = items.map((item) => item.name);
+    expect(names).toContain('real.txt');
+    expect(names).not.toContain('link.txt');
+    expect(items).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- ignore symbolic link dirents in `scanDirectory`
- add a test ensuring symlinks are excluded from results

## Testing
- `npx eslint src/main/folderScanner.js test/folderScanner.test.js`
- `npm test test/folderScanner.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a137cbf86c8324bced3174da81c015