### PR TITLE
Warn when login item settings update fails

### DIFF
--- a/src/main/ipc/settings.js
+++ b/src/main/ipc/settings.js
@@ -61,7 +61,12 @@ function registerSettingsIpc({
                 app.setLoginItemSettings({
                   openAtLogin: merged.launchOnStartup,
                 });
-              } catch {}
+              } catch (error) {
+                logger.warn(
+                  '[SETTINGS] Failed to set login item settings:',
+                  error.message,
+                );
+              }
             }
             logger.info('[SETTINGS] Saved settings');
             return { success: true, settings: merged };
@@ -87,7 +92,12 @@ function registerSettingsIpc({
                 app.setLoginItemSettings({
                   openAtLogin: merged.launchOnStartup,
                 });
-              } catch {}
+              } catch (error) {
+                logger.warn(
+                  '[SETTINGS] Failed to set login item settings:',
+                  error.message,
+                );
+              }
             }
             logger.info('[SETTINGS] Saved settings');
             return { success: true, settings: merged };


### PR DESCRIPTION
## Summary
- log a warning if updating startup settings fails in Settings IPC

## Testing
- `npx eslint src/main/ipc/settings.js`
- `npx prettier --check src/main/ipc/settings.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a137d462f483249aa478ce532f5e70