### PR TITLE
refactor: use logger in ollama utils

### DIFF
--- a/src/main/ollamaUtils.js
+++ b/src/main/ollamaUtils.js
@@ -3,6 +3,7 @@ const { Ollama } = require('ollama');
 const { app } = require('electron');
 const fs = require('fs').promises;
 const path = require('path');
+const { logger } = require('../shared/logger');
 
 // Path for storing Ollama configuration, e.g., selected model
 const getOllamaConfigPath = () => {
@@ -51,9 +52,9 @@ async function setOllamaModel(modelName) {
       // Keep legacy field for backward compatibility
       selectedModel: modelName,
     });
-    console.log(`[OLLAMA] Text model set to: ${modelName} and saved.`);
+    logger.info(`[OLLAMA] Text model set to: ${modelName} and saved.`);
   } catch (error) {
-    console.error(`[OLLAMA] Error saving text model selection:`, error);
+    logger.error(`[OLLAMA] Error saving text model selection:`, error);
   }
 }
 
@@ -65,9 +66,9 @@ async function setOllamaVisionModel(modelName) {
       ...current,
       selectedVisionModel: modelName,
     });
-    console.log(`[OLLAMA] Vision model set to: ${modelName} and saved.`);
+    logger.info(`[OLLAMA] Vision model set to: ${modelName} and saved.`);
   } catch (error) {
-    console.error(`[OLLAMA] Error saving vision model selection:`, error);
+    logger.error(`[OLLAMA] Error saving vision model selection:`, error);
   }
 }
 
@@ -79,9 +80,9 @@ async function setOllamaEmbeddingModel(modelName) {
       ...current,
       selectedEmbeddingModel: modelName,
     });
-    console.log(`[OLLAMA] Embedding model set to: ${modelName} and saved.`);
+    logger.info(`[OLLAMA] Embedding model set to: ${modelName} and saved.`);
   } catch (error) {
-    console.error(`[OLLAMA] Error saving embedding model selection:`, error);
+    logger.error(`[OLLAMA] Error saving embedding model selection:`, error);
   }
 }
 
@@ -97,10 +98,10 @@ async function setOllamaHost(host) {
       ollamaInstance = new Ollama({ host: ollamaHost });
       const current = await loadOllamaConfig();
       await saveOllamaConfig({ ...current, host: ollamaHost });
-      console.log(`[OLLAMA] Host set to: ${ollamaHost}`);
+      logger.info(`[OLLAMA] Host set to: ${ollamaHost}`);
     }
   } catch (error) {
-    console.error('[OLLAMA] Error setting host:', error);
+    logger.error('[OLLAMA] Error setting host:', error);
   }
 }
 
@@ -113,30 +114,30 @@ async function loadOllamaConfig() {
     // Support legacy and new keys
     if (config.selectedTextModel || config.selectedModel) {
       selectedTextModel = config.selectedTextModel || config.selectedModel;
-      console.log(`[OLLAMA] Loaded selected text model: ${selectedTextModel}`);
+      logger.info(`[OLLAMA] Loaded selected text model: ${selectedTextModel}`);
     }
     if (config.selectedVisionModel) {
       selectedVisionModel = config.selectedVisionModel;
-      console.log(
+      logger.info(
         `[OLLAMA] Loaded selected vision model: ${selectedVisionModel}`,
       );
     }
     if (config.selectedEmbeddingModel) {
       selectedEmbeddingModel = config.selectedEmbeddingModel;
-      console.log(
+      logger.info(
         `[OLLAMA] Loaded selected embedding model: ${selectedEmbeddingModel}`,
       );
     }
     if (config.host) {
       ollamaHost = config.host;
       ollamaInstance = new Ollama({ host: ollamaHost });
-      console.log(`[OLLAMA] Loaded host: ${ollamaHost}`);
+      logger.info(`[OLLAMA] Loaded host: ${ollamaHost}`);
     }
     return config;
   } catch (error) {
     // It's okay if the file doesn't exist on first run
     if (error.code !== 'ENOENT') {
-      console.error('[OLLAMA] Error loading Ollama config:', error);
+      logger.error('[OLLAMA] Error loading Ollama config:', error);
     }
     // Fallback to a default model or leave as null if no configuration is found
     // You might want to fetch available models and pick one if ollamaModel is still null
@@ -163,14 +164,14 @@ async function loadOllamaConfig() {
             foundModel = modelsResponse.models[0].name; // Fallback to the first model
           }
           await setOllamaModel(foundModel);
-          console.log(
+          logger.info(
             `[OLLAMA] No saved text model found, defaulted to: ${selectedTextModel}`,
           );
         } else {
-          console.warn('[OLLAMA] No models available from Ollama server.');
+          logger.warn('[OLLAMA] No models available from Ollama server.');
         }
       } catch (listError) {
-        console.error(
+        logger.error(
           '[OLLAMA] Error fetching model list during initial load:',
           listError,
         );
@@ -186,7 +187,7 @@ async function saveOllamaConfig(config) {
     const filePath = getOllamaConfigPath();
     await fs.writeFile(filePath, JSON.stringify(config, null, 2));
   } catch (error) {
-    console.error('[OLLAMA] Error saving Ollama config:', error);
+    logger.error('[OLLAMA] Error saving Ollama config:', error);
     throw error; // Re-throw to indicate save failure
   }
 }


### PR DESCRIPTION
## Summary
- replace console statements in ollama utils with shared logger

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a137d6d7a88324bc5b3c1de73f748b