### PR TITLE
Handle cross-device rename in atomicMove

### DIFF
--- a/src/shared/atomicFileOperations.js
+++ b/src/shared/atomicFileOperations.js
@@ -171,7 +171,17 @@ class AtomicFileOperations {
       destination = uniqueDestination;
     }
 
-    await fs.rename(source, destination);
+    try {
+      await fs.rename(source, destination);
+    } catch (error) {
+      if (error.code === 'EXDEV') {
+        await fs.copyFile(source, destination);
+        await fs.unlink(source);
+      } else {
+        throw error;
+      }
+    }
+
     return destination;
   }
 


### PR DESCRIPTION
## Summary
- add EXDEV fallback to `atomicMove`, copying across devices then removing source

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a137dc694c832481d000fb2865c104