### PR TITLE
feat: auto-organize downloads via watcher

### DIFF
--- a/src/main/ipc/index.js
+++ b/src/main/ipc/index.js
@@ -36,6 +36,7 @@ function registerAllIpc({
   setOllamaModel,
   setOllamaVisionModel,
   setOllamaEmbeddingModel,
+  onSettingsChanged,
 }) {
   registerFilesIpc({
     ipcMain,
@@ -102,6 +103,7 @@ function registerAllIpc({
     setOllamaModel,
     setOllamaVisionModel,
     setOllamaEmbeddingModel,
+    onSettingsChanged,
   });
   registerEmbeddingsIpc({
     ipcMain,

--- a/src/main/ipc/settings.js
+++ b/src/main/ipc/settings.js
@@ -16,6 +16,7 @@ function registerSettingsIpc({
   setOllamaModel,
   setOllamaVisionModel,
   setOllamaEmbeddingModel,
+  onSettingsChanged,
 }) {
   ipcMain.handle(
     IPC_CHANNELS.SETTINGS.GET,
@@ -38,6 +39,7 @@ function registerSettingsIpc({
           visionModel: z.string().optional(),
           embeddingModel: z.string().optional(),
           launchOnStartup: z.boolean().optional(),
+          autoOrganize: z.boolean().optional(),
         })
         .partial()
     : null;
@@ -69,6 +71,9 @@ function registerSettingsIpc({
               }
             }
             logger.info('[SETTINGS] Saved settings');
+            try {
+              onSettingsChanged?.(merged);
+            } catch {}
             return { success: true, settings: merged };
           } catch (error) {
             logger.error('Failed to save settings:', error);
@@ -100,6 +105,9 @@ function registerSettingsIpc({
               }
             }
             logger.info('[SETTINGS] Saved settings');
+            try {
+              onSettingsChanged?.(merged);
+            } catch {}
             return { success: true, settings: merged };
           } catch (error) {
             logger.error('Failed to save settings:', error);

--- a/src/main/services/DownloadWatcher.js
+++ b/src/main/services/DownloadWatcher.js
@@ -1,0 +1,112 @@
+const fs = require('fs').promises;
+const path = require('path');
+const os = require('os');
+const chokidar = require('chokidar');
+const { logger } = require('../../shared/logger');
+
+// Simple utility to determine if a path is an image based on extension
+const IMAGE_EXTENSIONS = new Set([
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.bmp',
+  '.webp',
+  '.tiff',
+  '.svg',
+  '.heic',
+]);
+
+class DownloadWatcher {
+  constructor({ analyzeDocumentFile, analyzeImageFile, getCustomFolders }) {
+    this.analyzeDocumentFile = analyzeDocumentFile;
+    this.analyzeImageFile = analyzeImageFile;
+    this.getCustomFolders = getCustomFolders;
+    this.watcher = null;
+  }
+
+  start() {
+    if (this.watcher) return;
+    const downloadsPath = path.join(os.homedir(), 'Downloads');
+    logger.info('[DOWNLOAD-WATCHER] Watching', downloadsPath);
+    this.watcher = chokidar.watch(downloadsPath, { ignoreInitial: true });
+    this.watcher.on('add', (filePath) => {
+      this.handleFile(filePath).catch((e) =>
+        logger.error('[DOWNLOAD-WATCHER] Failed processing', filePath, e),
+      );
+    });
+  }
+
+  stop() {
+    if (this.watcher) {
+      this.watcher.close();
+      this.watcher = null;
+    }
+  }
+
+  async handleFile(filePath) {
+    const ext = path.extname(filePath).toLowerCase();
+    if (ext === '' || ext.endsWith('crdownload') || ext.endsWith('tmp')) return;
+
+    const folders = this.getCustomFolders().filter((f) => f && f.path);
+    const folderCategories = folders.map((f) => ({
+      name: f.name,
+      description: f.description || '',
+      id: f.id,
+    }));
+
+    let result;
+    try {
+      if (IMAGE_EXTENSIONS.has(ext)) {
+        result = await this.analyzeImageFile(filePath, folderCategories);
+      } else {
+        result = await this.analyzeDocumentFile(filePath, folderCategories);
+      }
+    } catch (e) {
+      logger.error('[DOWNLOAD-WATCHER] Analysis failed', e);
+      return;
+    }
+
+    const destFolder = this.resolveDestinationFolder(result, folders);
+    if (!destFolder) return;
+    try {
+      await fs.mkdir(destFolder.path, { recursive: true });
+      const baseName = path.basename(filePath);
+      const extname = path.extname(baseName);
+      const newName = result.suggestedName
+        ? `${result.suggestedName}${extname}`
+        : baseName;
+      const destPath = path.join(destFolder.path, newName);
+      await fs.rename(filePath, destPath);
+      logger.info('[DOWNLOAD-WATCHER] Moved', filePath, '=>', destPath);
+    } catch (e) {
+      logger.error('[DOWNLOAD-WATCHER] Failed to move file', e);
+    }
+  }
+
+  resolveDestinationFolder(result, folders) {
+    if (!result) return null;
+    // Prefer explicit smartFolder id
+    if (result.smartFolder && result.smartFolder.id) {
+      return folders.find((f) => f.id === result.smartFolder.id);
+    }
+    // Try folder match candidates
+    if (Array.isArray(result.folderMatchCandidates)) {
+      for (const cand of result.folderMatchCandidates) {
+        const found = folders.find(
+          (f) => f.id === cand.id || f.name === cand.name,
+        );
+        if (found) return found;
+      }
+    }
+    // Fallback to category name match
+    if (result.category) {
+      return folders.find(
+        (f) => f.name.toLowerCase() === result.category.toLowerCase(),
+      );
+    }
+    return null;
+  }
+}
+
+module.exports = DownloadWatcher;

--- a/src/main/simple-main.js
+++ b/src/main/simple-main.js
@@ -34,6 +34,7 @@ const {
 // const ModelManager = require('./services/ModelManager'); // not used currently
 const { buildOllamaOptions } = require('./services/PerformanceService');
 const SettingsService = require('./services/SettingsService');
+const DownloadWatcher = require('./services/DownloadWatcher');
 
 // Import service integration
 const ServiceIntegration = require('./services/ServiceIntegration');
@@ -55,6 +56,7 @@ let customFolders = []; // Initialize customFolders at module level
 // Initialize service integration
 let serviceIntegration;
 let settingsService;
+let downloadWatcher;
 
 // Custom folders helpers
 const {
@@ -78,6 +80,23 @@ function createWindow() {
   mainWindow.on('closed', () => {
     mainWindow = null;
   });
+}
+
+function updateDownloadWatcher(settings) {
+  const enabled = settings?.autoOrganize;
+  if (enabled) {
+    if (!downloadWatcher) {
+      downloadWatcher = new DownloadWatcher({
+        analyzeDocumentFile,
+        analyzeImageFile,
+        getCustomFolders: () => customFolders,
+      });
+      downloadWatcher.start();
+    }
+  } else if (downloadWatcher) {
+    downloadWatcher.stop();
+    downloadWatcher = null;
+  }
 }
 
 // ===== IPC HANDLERS =====
@@ -226,6 +245,7 @@ if (!gotTheLock) {
       logger.info('[MAIN] Service integration initialized successfully');
       // Initialize settings service
       settingsService = new SettingsService();
+      const initialSettings = await settingsService.load();
 
       // Resume any incomplete organize batches (best-effort)
       try {
@@ -303,9 +323,11 @@ if (!gotTheLock) {
         setOllamaModel,
         setOllamaVisionModel,
         setOllamaEmbeddingModel,
+        onSettingsChanged: updateDownloadWatcher,
       });
 
       createWindow();
+      updateDownloadWatcher(initialSettings);
       // Create system tray with quick actions
       try {
         createSystemTray();

--- a/src/renderer/components/SettingsPanel.jsx
+++ b/src/renderer/components/SettingsPanel.jsx
@@ -6,6 +6,7 @@ import Input from './ui/Input';
 import Textarea from './ui/Textarea';
 import Select from './ui/Select';
 import Collapsible from './ui/Collapsible';
+import AutoOrganizeSection from './settings/AutoOrganizeSection';
 
 function SettingsPanel() {
   const { actions } = usePhase();
@@ -494,26 +495,10 @@ function SettingsPanel() {
                   className="w-full"
                 />
               </div>
-              <div className="flex items-center">
-                <input
-                  type="checkbox"
-                  id="autoOrganize"
-                  checked={settings.autoOrganize}
-                  onChange={(e) =>
-                    setSettings((prev) => ({
-                      ...prev,
-                      autoOrganize: e.target.checked,
-                    }))
-                  }
-                  className="mr-8"
-                />
-                <label
-                  htmlFor="autoOrganize"
-                  className="text-sm text-system-gray-700"
-                >
-                  Auto-organize files after analysis
-                </label>
-              </div>
+              <AutoOrganizeSection
+                settings={settings}
+                setSettings={setSettings}
+              />
             </div>
           </Collapsible>
 

--- a/src/renderer/components/settings/AutoOrganizeSection.jsx
+++ b/src/renderer/components/settings/AutoOrganizeSection.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+function AutoOrganizeSection({ settings, setSettings }) {
+  return (
+    <label className="flex items-center gap-5">
+      <input
+        type="checkbox"
+        checked={settings.autoOrganize}
+        onChange={(e) =>
+          setSettings((prev) => ({
+            ...prev,
+            autoOrganize: e.target.checked,
+          }))
+        }
+      />
+      <span className="text-sm text-system-gray-700">
+        Automatically organize new downloads
+      </span>
+    </label>
+  );
+}
+
+export default AutoOrganizeSection;


### PR DESCRIPTION
## Summary
- watch Downloads folder for new files and analyze/organize them
- allow users to toggle auto-organization in settings
- start/stop download watcher based on persisted setting
- align auto-organize settings toggle with existing UI conventions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a18292973483248bef3e74c69232f6