### PR TITLE
feat: add background mode and tray controls

### DIFF
--- a/src/main/ipc/settings.js
+++ b/src/main/ipc/settings.js
@@ -40,6 +40,7 @@ function registerSettingsIpc({
           embeddingModel: z.string().optional(),
           launchOnStartup: z.boolean().optional(),
           autoOrganize: z.boolean().optional(),
+          backgroundMode: z.boolean().optional(),
         })
         .partial()
     : null;

--- a/src/main/services/SettingsService.js
+++ b/src/main/services/SettingsService.js
@@ -14,6 +14,7 @@ class SettingsService {
       defaultSmartFolderLocation: 'Documents',
       maxConcurrentAnalysis: 3,
       autoOrganize: false,
+      backgroundMode: false,
       // AI
       ollamaHost: 'http://127.0.0.1:11434',
       textModel: 'llama3.2:latest',

--- a/src/main/simple-main.js
+++ b/src/main/simple-main.js
@@ -57,6 +57,8 @@ let customFolders = []; // Initialize customFolders at module level
 let serviceIntegration;
 let settingsService;
 let downloadWatcher;
+let currentSettings = {};
+let isQuitting = false;
 
 // Custom folders helpers
 const {
@@ -77,6 +79,12 @@ function createWindow() {
     return;
   }
   mainWindow = createMainWindow();
+  mainWindow.on('close', (e) => {
+    if (!isQuitting && currentSettings?.backgroundMode) {
+      e.preventDefault();
+      mainWindow.hide();
+    }
+  });
   mainWindow.on('closed', () => {
     mainWindow = null;
   });
@@ -97,6 +105,14 @@ function updateDownloadWatcher(settings) {
     downloadWatcher.stop();
     downloadWatcher = null;
   }
+}
+
+function handleSettingsChanged(settings) {
+  currentSettings = settings || {};
+  updateDownloadWatcher(settings);
+  try {
+    updateTrayMenu();
+  } catch {}
 }
 
 // ===== IPC HANDLERS =====
@@ -323,11 +339,11 @@ if (!gotTheLock) {
         setOllamaModel,
         setOllamaVisionModel,
         setOllamaEmbeddingModel,
-        onSettingsChanged: updateDownloadWatcher,
+        onSettingsChanged: handleSettingsChanged,
       });
 
       createWindow();
-      updateDownloadWatcher(initialSettings);
+      handleSettingsChanged(initialSettings);
       // Create system tray with quick actions
       try {
         createSystemTray();
@@ -455,8 +471,14 @@ logger.info(
 logger.info('[UI] Modern UI loaded with GPU acceleration');
 
 // App lifecycle
+app.on('before-quit', () => {
+  isQuitting = true;
+  try {
+    systemAnalytics.destroy();
+  } catch {}
+});
+
 app.on('window-all-closed', () => {
-  systemAnalytics.destroy();
   if (process.platform !== 'darwin') {
     app.quit();
   }
@@ -466,10 +488,6 @@ app.on('activate', () => {
   if (BrowserWindow.getAllWindows().length === 0) {
     createWindow();
   }
-});
-
-app.on('before-quit', () => {
-  systemAnalytics.destroy();
 });
 
 // Smart folders add moved to ipc/smartFolders.js
@@ -543,58 +561,69 @@ logger.debug(
 let tray = null;
 function createSystemTray() {
   try {
-    const iconPath = require('path').join(
+    const path = require('path');
+    const iconPath = path.join(
       __dirname,
-      '../../assets/icons/icons/win/icon.ico',
+      process.platform === 'win32'
+        ? '../../assets/icons/icons/win/icon.ico'
+        : process.platform === 'darwin'
+          ? '../../assets/icons/icons/png/24x24.png'
+          : '../../assets/icons/icons/png/16x16.png',
     );
     const trayIcon = nativeImage.createFromPath(iconPath);
+    if (process.platform === 'darwin') {
+      trayIcon.setTemplateImage(true);
+    }
     tray = new Tray(trayIcon);
     tray.setToolTip('StratoSort');
-    const contextMenu = Menu.buildFromTemplate([
-      {
-        label: 'Open StratoSort',
-        click: () => {
-          const win = BrowserWindow.getAllWindows()[0] || createWindow();
-          if (win && win.isMinimized()) win.restore();
-          if (win) {
-            win.show();
-            win.focus();
-          }
-        },
-      },
-      {
-        label: 'Analyze Folder…',
-        click: async () => {
-          const win = BrowserWindow.getAllWindows()[0] || createWindow();
-          if (win && win.isMinimized()) win.restore();
-          if (win) {
-            win.show();
-            win.focus();
-          }
-          try {
-            const { canceled, filePaths } = await dialog.showOpenDialog(win, {
-              properties: ['openDirectory', 'dontAddToRecent'],
-            });
-            if (!canceled && filePaths && filePaths[0]) {
-              win.webContents.send('operation-progress', {
-                type: 'hint',
-                message: `Selected folder: ${filePaths[0]}`,
-              });
-            }
-          } catch {}
-        },
-      },
-      { type: 'separator' },
-      {
-        label: 'Quit',
-        click: () => {
-          app.quit();
-        },
-      },
-    ]);
-    tray.setContextMenu(contextMenu);
+    updateTrayMenu();
   } catch (e) {
     // eslint-disable-next-line no-console
     console.warn('[TRAY] initialization failed', e);
   }
+}
+
+function updateTrayMenu() {
+  if (!tray) return;
+  const contextMenu = Menu.buildFromTemplate([
+    {
+      label: 'Open StratoSort',
+      click: () => {
+        const win = BrowserWindow.getAllWindows()[0] || createWindow();
+        if (win && win.isMinimized()) win.restore();
+        if (win) {
+          win.show();
+          win.focus();
+        }
+      },
+    },
+    {
+      label: downloadWatcher ? 'Pause Auto-Sort' : 'Resume Auto-Sort',
+      click: async () => {
+        const enable = !downloadWatcher;
+        try {
+          if (settingsService) {
+            const merged = await settingsService.save({
+              autoOrganize: enable,
+            });
+            handleSettingsChanged(merged);
+          } else {
+            handleSettingsChanged({ autoOrganize: enable });
+          }
+        } catch (err) {
+          logger.warn('[TRAY] Failed to toggle auto-sort:', err.message);
+        }
+        updateTrayMenu();
+      },
+    },
+    { type: 'separator' },
+    {
+      label: 'Quit',
+      click: () => {
+        isQuitting = true;
+        app.quit();
+      },
+    },
+  ]);
+  tray.setContextMenu(contextMenu);
 }

--- a/src/renderer/components/SettingsPanel.jsx
+++ b/src/renderer/components/SettingsPanel.jsx
@@ -7,6 +7,7 @@ import Textarea from './ui/Textarea';
 import Select from './ui/Select';
 import Collapsible from './ui/Collapsible';
 import AutoOrganizeSection from './settings/AutoOrganizeSection';
+import BackgroundModeSection from './settings/BackgroundModeSection';
 
 function SettingsPanel() {
   const { actions } = usePhase();
@@ -18,6 +19,7 @@ function SettingsPanel() {
     embeddingModel: 'mxbai-embed-large',
     maxConcurrentAnalysis: 3,
     autoOrganize: false,
+    backgroundMode: false,
     defaultSmartFolderLocation: 'Documents',
   });
   const [ollamaModelLists, setOllamaModelLists] = useState({
@@ -496,6 +498,10 @@ function SettingsPanel() {
                 />
               </div>
               <AutoOrganizeSection
+                settings={settings}
+                setSettings={setSettings}
+              />
+              <BackgroundModeSection
                 settings={settings}
                 setSettings={setSettings}
               />

--- a/src/renderer/components/settings/BackgroundModeSection.jsx
+++ b/src/renderer/components/settings/BackgroundModeSection.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+function BackgroundModeSection({ settings, setSettings }) {
+  return (
+    <label className="flex items-center gap-5">
+      <input
+        type="checkbox"
+        checked={settings.backgroundMode}
+        onChange={(e) =>
+          setSettings((prev) => ({
+            ...prev,
+            backgroundMode: e.target.checked,
+          }))
+        }
+      />
+      <span className="text-sm text-system-gray-700">
+        Keep running in background
+      </span>
+    </label>
+  );
+}
+
+export default BackgroundModeSection;


### PR DESCRIPTION
## Summary
- add background mode setting and tray controls
- hide to tray when background mode enabled
- use platform specific tray icons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1cfa131148324aa9133d82c4abd62