### PR TITLE
chore(ci): align node versions across workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,15 +50,15 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
-          cache: 'npm'
+          node-version: 20
+          cache: npm
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Jest (quick)
+      - name: Tests
         env:
           CI: true
           NODE_ENV: test
           OLLAMA_BASE_URL: http://127.0.0.1:11434
-        run: npm test -- --bail --runInBand
+        run: npm test -- --coverage

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -13,10 +13,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Use Node.js 18
+      - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: 20
+          cache: npm
 
       - name: Install dependencies (CI)
         run: npm ci


### PR DESCRIPTION
## Summary
- use Node 20 for Windows CI and release workflows
- run full test suite with coverage on Windows CI
- cache npm dependencies in release workflow

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1ed2385c883249b59c924a042c816