### PR TITLE
feat: manage Ollama models from settings

### DIFF
--- a/src/main/ipc/ollama.js
+++ b/src/main/ipc/ollama.js
@@ -183,6 +183,21 @@ function registerOllamaIpc({
       }
     }),
   );
+
+  // Delete a model
+  ipcMain.handle(
+    IPC_CHANNELS.OLLAMA.DELETE_MODEL,
+    withErrorLogging(logger, async (_event, model) => {
+      try {
+        const ollama = getOllama();
+        await ollama.delete({ model });
+        return { success: true };
+      } catch (error) {
+        logger.error('[IPC] Delete model failed]:', error);
+        return { success: false, error: error.message };
+      }
+    }),
+  );
 }
 
 module.exports = registerOllamaIpc;

--- a/src/preload/preload.js
+++ b/src/preload/preload.js
@@ -460,6 +460,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       secureIPC.safeInvoke(IPC_CHANNELS.OLLAMA.TEST_CONNECTION, hostUrl),
     pullModels: (models) =>
       secureIPC.safeInvoke(IPC_CHANNELS.OLLAMA.PULL_MODELS, models),
+    deleteModel: (model) =>
+      secureIPC.safeInvoke(IPC_CHANNELS.OLLAMA.DELETE_MODEL, model),
   },
 
   // Event Listeners (with automatic cleanup)

--- a/src/renderer/components/SettingsPanel.jsx
+++ b/src/renderer/components/SettingsPanel.jsx
@@ -36,6 +36,10 @@ function SettingsPanel() {
   const [isRebuildingFolders, setIsRebuildingFolders] = useState(false);
   const [isRebuildingFiles, setIsRebuildingFiles] = useState(false);
   const [settingsLoaded, setSettingsLoaded] = useState(false);
+  const [newModel, setNewModel] = useState('');
+  const [modelToDelete, setModelToDelete] = useState('');
+  const [isAddingModel, setIsAddingModel] = useState(false);
+  const [isDeletingModel, setIsDeletingModel] = useState(false);
   const didAutoHealthCheckRef = useRef(false);
 
   useEffect(() => {
@@ -111,6 +115,7 @@ function SettingsPanel() {
         embedding: categories.embedding || [],
         all: response?.models || [],
       });
+      setModelToDelete((response?.models || [])[0] || '');
       if (response?.ollamaHealth) setOllamaHealth(response.ollamaHealth);
       if (response?.selected) {
         setSettings((prev) => ({
@@ -164,6 +169,51 @@ function SettingsPanel() {
       }
     } catch (e) {
       addNotification(`Ollama test failed: ${e.message}`, 'error');
+    }
+  };
+
+  const addOllamaModel = async () => {
+    if (!newModel.trim()) return;
+    try {
+      setIsAddingModel(true);
+      const res = await window.electronAPI.ollama.pullModels([newModel.trim()]);
+      const result = res?.results?.[0];
+      if (result?.success) {
+        addNotification(`Added model ${newModel.trim()}`, 'success');
+        setNewModel('');
+        await loadOllamaModels();
+      } else {
+        addNotification(
+          `Failed to add model: ${result?.error || 'Unknown error'}`,
+          'error',
+        );
+      }
+    } catch (e) {
+      addNotification(`Failed to add model: ${e.message}`, 'error');
+    } finally {
+      setIsAddingModel(false);
+    }
+  };
+
+  const deleteOllamaModel = async () => {
+    if (!modelToDelete) return;
+    try {
+      setIsDeletingModel(true);
+      const res = await window.electronAPI.ollama.deleteModel(modelToDelete);
+      if (res?.success) {
+        addNotification(`Deleted model ${modelToDelete}`, 'success');
+        setModelToDelete('');
+        await loadOllamaModels();
+      } else {
+        addNotification(
+          `Failed to delete model: ${res?.error || 'Unknown error'}`,
+          'error',
+        );
+      }
+    } catch (e) {
+      addNotification(`Failed to delete model: ${e.message}`, 'error');
+    } finally {
+      setIsDeletingModel(false);
     }
   };
 
@@ -401,6 +451,61 @@ function SettingsPanel() {
                       </option>
                     ))}
                   </Select>
+                </div>
+              </div>
+              <div className="border-t border-system-gray-200 pt-13 mt-13 space-y-13">
+                <div>
+                  <label className="block text-sm font-medium text-system-gray-700 mb-5">
+                    Add Model
+                  </label>
+                  <div className="flex gap-8">
+                    <Input
+                      type="text"
+                      value={newModel}
+                      onChange={(e) => setNewModel(e.target.value)}
+                      placeholder="model:tag"
+                      className="flex-1"
+                    />
+                    <Button
+                      onClick={addOllamaModel}
+                      variant="secondary"
+                      type="button"
+                      disabled={isAddingModel}
+                      title="Pull model"
+                    >
+                      {isAddingModel ? 'Adding…' : 'Add'}
+                    </Button>
+                  </div>
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-system-gray-700 mb-5">
+                    Delete Model
+                  </label>
+                  <div className="flex gap-8">
+                    <Select
+                      value={modelToDelete}
+                      onChange={(e) => setModelToDelete(e.target.value)}
+                      className="flex-1"
+                    >
+                      <option value="" disabled>
+                        Select model
+                      </option>
+                      {ollamaModelLists.all.map((model) => (
+                        <option key={model} value={model}>
+                          {model}
+                        </option>
+                      ))}
+                    </Select>
+                    <Button
+                      onClick={deleteOllamaModel}
+                      variant="danger"
+                      type="button"
+                      disabled={isDeletingModel || !modelToDelete}
+                      title="Delete model"
+                    >
+                      {isDeletingModel ? 'Deleting…' : 'Delete'}
+                    </Button>
+                  </div>
                 </div>
               </div>
               <div className="grid grid-cols-1 md:grid-cols-3 gap-13">

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -114,6 +114,7 @@ const IPC_CHANNELS = {
     GET_MODELS: 'get-ollama-models',
     TEST_CONNECTION: 'test-ollama-connection',
     PULL_MODELS: 'ollama-pull-models',
+    DELETE_MODEL: 'ollama-delete-model',
   },
 
   // Undo/Redo


### PR DESCRIPTION
## Summary
- allow adding and deleting Ollama models directly from the Settings panel
- expose IPC and preload helpers to delete models
- update constants for new IPC channel

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1ed400f30832495ad6f2c2c5b9e45