### PR TITLE
Add optional Ollama installation during setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,8 @@ lerna-debug.log*
 # Production builds
 dist/
 release/
-build/
+build/*
+!build/installer.nsh
 out/
 
 # Development

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Privacy-first, local AI document organizer (Electron + React). Analyze documents
 Prereqs:
 
 - Node.js 18+ and npm 8+
-- Optional: Ollama for AI features (app runs without it; AI disabled)
+- Optional: Ollama for AI features (installer can fetch and start it)
 
 Install & run:
 
@@ -27,7 +27,9 @@ npm run dev
 
 Ollama (optional):
 
-- Install from `https://ollama.ai` and start the server: `ollama serve`
+- During installation StratoSort checks for Ollama and offers to install and start it
+- On launch StratoSort verifies the Ollama server is running and attempts to start it if needed
+- You can also install manually from `https://ollama.ai` and start the server: `ollama serve`
 - Pull your preferred text/vision/embedding models
 - In the app: Settings → AI Configuration → set Host and model names
 - Or run: `npm run setup:ollama` to attempt pulling example models

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,0 +1,13 @@
+!macro customInstall
+  DetailPrint "Checking for Ollama..."
+  nsExec::ExecToStack 'powershell -NoProfile -Command "if (Get-Command ollama -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }"'
+  Pop $0
+  StrCmp $0 0 ollamaInstalled
+  MessageBox MB_YESNO "Ollama is not installed. Install now?" IDNO skipInstall
+  DetailPrint "Installing Ollama via winget"
+  nsExec::ExecToLog 'powershell -NoProfile -Command "winget install -e --id Ollama.Ollama"'
+ollamaInstalled:
+  DetailPrint "Starting Ollama server"
+  nsExec::ExecToLog 'powershell -NoProfile -Command "Start-Process ollama -ArgumentList serve -WindowStyle Hidden"'
+skipInstall:
+!macroend

--- a/src/main/simple-main.js
+++ b/src/main/simple-main.js
@@ -48,6 +48,8 @@ const { analyzeImageFile } = require('./analysis/ollamaImageAnalysis');
 
 // Import OCR library
 const tesseract = require('node-tesseract-ocr');
+const { spawn } = require('child_process');
+const fetch = global.fetch || require('node-fetch');
 
 let mainWindow;
 let customFolders = []; // Initialize customFolders at module level
@@ -58,6 +60,47 @@ let settingsService;
 let downloadWatcher;
 let currentSettings = {};
 let isQuitting = false;
+
+async function ensureOllamaRunning() {
+  if (process.env.CI) return;
+  await loadOllamaConfig();
+  const host = getOllamaHost();
+
+  async function check() {
+    try {
+      const res = await fetch(`${host}/api/tags`);
+      return res && res.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  if (await check()) {
+    return;
+  }
+  try {
+    logger.info(`[STARTUP] Ollama not reachable at ${host}, starting server`);
+    const child = spawn('ollama', ['serve'], {
+      detached: true,
+      stdio: 'ignore',
+      shell: process.platform === 'win32',
+    });
+    child.unref();
+  } catch (e) {
+    logger.warn('[STARTUP] Failed to launch ollama serve', e);
+    return;
+  }
+
+  for (let i = 0; i < 10; i += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise((r) => setTimeout(r, 500));
+    if (await check()) {
+      logger.info('[STARTUP] Ollama server started');
+      return;
+    }
+  }
+  logger.warn('[STARTUP] Ollama did not respond after start attempt');
+}
 
 // ===== GPU PREFERENCES (Windows rendering stability) =====
 try {
@@ -392,6 +435,7 @@ if (!gotTheLock) {
   // Initialize services after app is ready
   app.whenReady().then(async () => {
     try {
+      await ensureOllamaRunning();
       // Load custom folders
       customFolders = await loadCustomFolders();
       logger.info(


### PR DESCRIPTION
## Summary
- add NSIS installer snippet that checks for Ollama, offers winget-based install, and starts the server
- document installer behaviour in README
- ensure app launch checks Ollama and starts server if absent

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4f8efabc08324a6a499b3f794c86a