### PR TITLE
feat: validate LLM folder names

### DIFF
--- a/src/main/services/OrganizationSuggestionService.js
+++ b/src/main/services/OrganizationSuggestionService.js
@@ -5,6 +5,7 @@ const {
   getOllamaModel,
   buildOllamaOptions,
 } = require('../ollamaUtils');
+const { sanitizeLLMFolderName } = require('../../shared/folderNameUtils');
 
 class OrganizationSuggestionService {
   constructor({ embeddingService, folderMatchingService, settingsService }) {
@@ -382,33 +383,16 @@ Return JSON: {
 
       const parsed = JSON.parse(response.response);
       return (parsed.suggestions || []).map((s) => {
-        // Validate and sanitize folder name
-        let folderName = s.folder || 'General';
-
-        // If folder name is too long or contains description text, truncate it
-        if (folderName.length > 50 || folderName.includes('To provide')) {
+        const original = s.folder;
+        const folderName = sanitizeLLMFolderName(original);
+        if (folderName === 'General' && original && original !== 'General') {
           logger.warn(
             '[OrganizationSuggestionService] LLM returned invalid folder name:',
             {
-              original: folderName,
+              original,
               file: file.name,
             },
           );
-
-          // Try to extract a valid folder name
-          if (folderName.includes(':')) {
-            folderName = folderName.split(':')[0].trim();
-          } else if (folderName.includes('\\')) {
-            folderName = folderName.split('\\')[0].trim();
-          } else {
-            // Take first few words
-            folderName = folderName.split(' ').slice(0, 2).join(' ');
-          }
-
-          // Final sanitization
-          if (folderName.length > 50) {
-            folderName = 'General';
-          }
         }
 
         const matched = smartFolders.find(

--- a/src/main/services/SmartFoldersLLMService.js
+++ b/src/main/services/SmartFoldersLLMService.js
@@ -1,4 +1,5 @@
 const { logger } = require('../../shared/logger');
+const { sanitizeLLMFolderName } = require('../../shared/folderNameUtils');
 
 async function enhanceSmartFolderWithLLM(
   folderData,
@@ -10,6 +11,12 @@ async function enhanceSmartFolderWithLLM(
       '[LLM-ENHANCEMENT] Analyzing smart folder for optimization:',
       folderData.name,
     );
+    const safeName = sanitizeLLMFolderName(folderData.name);
+    if (safeName === 'General' && folderData.name !== 'General') {
+      logger.warn('[LLM-ENHANCEMENT] Invalid folder name provided:', {
+        original: folderData.name,
+      });
+    }
 
     const existingFolderContext = existingFolders.map((f) => ({
       name: f.name,
@@ -21,7 +28,7 @@ async function enhanceSmartFolderWithLLM(
     const prompt = `You are an expert file organization system. Analyze this new smart folder and provide enhancements based on existing folder structure.
 
 NEW FOLDER:
-Name: "${folderData.name}"
+Name: "${safeName}"
 Path: "${folderData.path}"
 Description: "${folderData.description || ''}"
 
@@ -79,10 +86,16 @@ async function calculateFolderSimilarities(
   getOllamaModel,
 ) {
   try {
+    const safeCategory = sanitizeLLMFolderName(suggestedCategory);
+    if (safeCategory === 'General' && suggestedCategory !== 'General') {
+      logger.warn('[SEMANTIC] Invalid suggested category:', {
+        original: suggestedCategory,
+      });
+    }
     const similarities = [];
     for (const folder of folderCategories) {
       const prompt = `Compare these two categories for semantic similarity:
-Category 1: "${suggestedCategory}"
+Category 1: "${safeCategory}"
 Category 2: "${folder.name}" (Description: "${folder.description}")
 
 Rate similarity from 0.0 to 1.0 where:
@@ -130,7 +143,7 @@ Respond with only a number between 0.0 and 1.0:`;
           folderError.message,
         );
         const basicSimilarity = calculateBasicSimilarity(
-          suggestedCategory,
+          safeCategory,
           folder.name,
         );
         similarities.push({

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -278,6 +278,13 @@ const TIMEOUTS = {
   THROTTLE: 100,
 };
 
+// Allowed folder naming patterns
+const FOLDER_NAME_PATTERNS = [
+  /^[A-Z][a-z0-9]+(?:[A-Z][a-z0-9]+)*$/, // PascalCase
+  /^[a-z][a-z0-9]+(?:[A-Z][a-z0-9]+)*$/, // camelCase
+  /^[a-z0-9]+(?:-[a-z0-9]+)*$/, // kebab-case
+];
+
 // File type mappings
 const SUPPORTED_TEXT_EXTENSIONS = [
   '.txt',
@@ -435,6 +442,7 @@ module.exports = {
   SHORTCUTS,
   LIMITS,
   TIMEOUTS,
+  FOLDER_NAME_PATTERNS,
   SUPPORTED_TEXT_EXTENSIONS,
   SUPPORTED_DOCUMENT_EXTENSIONS,
   SUPPORTED_IMAGE_EXTENSIONS,

--- a/src/shared/folderNameUtils.js
+++ b/src/shared/folderNameUtils.js
@@ -1,0 +1,50 @@
+const { FOLDER_NAME_PATTERNS } = require('./constants');
+
+const STOPWORDS = [
+  'to',
+  'for',
+  'the',
+  'and',
+  'with',
+  'from',
+  'that',
+  'this',
+  'provide',
+  'ensure',
+  'help',
+  'assist',
+];
+
+function sanitizeLLMFolderName(rawName) {
+  if (!rawName) return 'General';
+  let candidate = String(rawName)
+    .split(/[\\/:,.;?!\n]/)[0]
+    .replace(/^["']|["']$/g, '')
+    .trim();
+  candidate = candidate.replace(/[^A-Za-z0-9 _-]/g, '').trim();
+  const words = candidate.split(/\s+/).filter(Boolean);
+  if (words.length === 0 || words.length > 3) return 'General';
+  if (words.some((w) => STOPWORDS.includes(w.toLowerCase()))) return 'General';
+
+  if (words.length > 1) {
+    candidate = words
+      .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+      .join('');
+  } else {
+    candidate = words[0];
+    if (!FOLDER_NAME_PATTERNS.some((r) => r.test(candidate))) {
+      candidate = candidate.charAt(0).toUpperCase() + candidate.slice(1);
+    }
+  }
+
+  let normalized = candidate.replace(/[^A-Za-z0-9_-]/g, '');
+  if (normalized.length > 50) {
+    normalized = normalized.slice(0, 50);
+  }
+  if (!normalized || !FOLDER_NAME_PATTERNS.some((r) => r.test(normalized))) {
+    return 'General';
+  }
+  return normalized;
+}
+
+module.exports = { sanitizeLLMFolderName };

--- a/test/folder-name-utils.test.js
+++ b/test/folder-name-utils.test.js
@@ -1,0 +1,23 @@
+const { sanitizeLLMFolderName } = require('../src/shared/folderNameUtils');
+
+describe('sanitizeLLMFolderName', () => {
+  test('converts simple phrases to PascalCase', () => {
+    expect(sanitizeLLMFolderName('financial reports')).toBe('FinancialReports');
+    expect(sanitizeLLMFolderName('project-x')).toBe('project-x');
+  });
+
+  test('rejects descriptive sentences', () => {
+    const sentence =
+      'To provide financial assistance for dental treatment to those who cannot afford it';
+    expect(sanitizeLLMFolderName(sentence)).toBe('General');
+  });
+
+  test('rejects inputs with stopwords or many words', () => {
+    expect(sanitizeLLMFolderName('This is a descriptive sentence')).toBe(
+      'General',
+    );
+    expect(sanitizeLLMFolderName('grant funding application for college')).toBe(
+      'General',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- centralize folder name sanitization with shared helper
- reject descriptive sentences using stopwords and word-count heuristics
- cover folder name sanitizer with unit tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7ecf9ae7c8324b3a5ee4ee6dd52a2