### PR TITLE
fix: cleanup rollback transactions

### DIFF
--- a/src/shared/atomicFileOperations.js
+++ b/src/shared/atomicFileOperations.js
@@ -329,6 +329,7 @@ class AtomicFileOperations {
       // Attempt to rollback
       try {
         await this.rollbackTransaction(transactionId);
+        await this.cleanupBackups(transactionId);
         return {
           success: false,
           error: error.message,

--- a/test/atomic-file-operations.test.js
+++ b/test/atomic-file-operations.test.js
@@ -1,0 +1,49 @@
+const path = require('path');
+const fs = require('fs').promises;
+const os = require('os');
+
+const { atomicFileOps } = require('../src/shared/atomicFileOperations');
+
+describe('AtomicFileOperations', () => {
+  const tempDir = path.join(os.tmpdir(), 'atomic-file-op-tests');
+
+  beforeEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+    await fs.mkdir(tempDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  test('cleans up transaction after rollback', async () => {
+    const source = path.join(tempDir, 'a.txt');
+    const dest = path.join(tempDir, 'dest', 'a.txt');
+    await fs.writeFile(source, 'content');
+
+    const transactionId = await atomicFileOps.beginTransaction();
+
+    atomicFileOps.addOperation(transactionId, {
+      type: 'move',
+      source,
+      destination: dest,
+    });
+
+    // Add a failing operation to trigger rollback
+    atomicFileOps.addOperation(transactionId, {
+      type: 'move',
+      source: path.join(tempDir, 'missing.txt'),
+      destination: path.join(tempDir, 'dest', 'missing.txt'),
+    });
+
+    const result = await atomicFileOps.commitTransaction(transactionId);
+    expect(result.success).toBe(false);
+    expect(result.rollbackSuccessful).toBe(true);
+
+    // Transaction should be cleaned up
+    expect(atomicFileOps.getTransactionStatus(transactionId)).toBeNull();
+
+    // Original file should still exist
+    await expect(fs.access(source)).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- ensure rollback transactions clean up backups and remove themselves from active list
- add regression test for rollback cleanup

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a8ce7712488324aed77de5475b42c7