### PR TITLE
Fix contentLength fallback in normalizeAnalysisResult

### DIFF
--- a/src/main/analysis/utils.js
+++ b/src/main/analysis/utils.js
@@ -21,7 +21,7 @@ function normalizeAnalysisResult(raw, fallback = {}) {
     contentLength:
       typeof result.contentLength === 'number'
         ? result.contentLength
-        : fallback.contentLength || null,
+        : (fallback.contentLength ?? null),
   };
   return { ...result, ...normalized };
 }

--- a/test/analysis-utils.test.js
+++ b/test/analysis-utils.test.js
@@ -1,0 +1,8 @@
+const { normalizeAnalysisResult } = require('../src/main/analysis/utils');
+
+describe('normalizeAnalysisResult', () => {
+  test('preserves fallback contentLength of 0', () => {
+    const result = normalizeAnalysisResult({}, { contentLength: 0 });
+    expect(result.contentLength).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure `normalizeAnalysisResult` keeps `contentLength` of 0 instead of coercing to null
- add test for `normalizeAnalysisResult` contentLength fallback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8cf034ffc8324976d887ee8acca91